### PR TITLE
fix: polish v2.0.0 — clean up logs, dead code, README, and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Add the following entry to the `mcpServers` section:
 
 Replace `<path_to_creds.json>` with the absolute path to your `creds.json` file.
 
-> **Docker Image Tags:** Use `searchunifyutils/su-mcp` (defaults to `latest`) or pin a specific version with `searchunifyutils/su-mcp:1.1.0`. Available tags are published on [Docker Hub](https://hub.docker.com/r/searchunifyutils/su-mcp).
+> **Docker Image Tags:** Use `searchunifyutils/su-mcp` (defaults to `latest`) or pin a specific version with `searchunifyutils/su-mcp:2.0.0`. Available tags are published on [Docker Hub](https://hub.docker.com/r/searchunifyutils/su-mcp).
 
 #### Step 3 -- Restart Claude Desktop
 
@@ -531,29 +531,30 @@ When a user connects via Claude's directory:
 
 ---
 
-### Integration 5: Tool-Based Login via `/mcp-connect` (No Browser Required)
+### Integration 5: Tool-Based Login via `/mcp-connect`
 
-Use this integration when Claude Desktop **cannot auto-open a browser** to complete the OAuth flow (e.g. headless or restricted environments). Instead of opening a browser automatically, Claude surfaces a link in the chat — the user clicks it manually to open the connection form.
+Use this integration when the standard OAuth flow (Integration 4) does not work — for example when Claude Desktop fails to auto-complete the browser redirect, or when you prefer to initiate login manually from within the chat.
+
+A browser **is required** — the difference from Integration 4 is that the browser is opened **manually** by clicking a link surfaced in the chat, rather than being opened automatically by mcp-remote.
 
 **How it works:**
 ```
-Claude Desktop → connects to /mcp-connect (no OAuth, no browser)
-→ Claude calls login() tool
+Claude Desktop → connects to /mcp-connect
+→ Claude calls login() tool automatically
 → Chat shows: [Connect SearchUnify](https://mcp.searchunify.com/mcp-connect/login?s=...)
-→ User clicks link → same connection form (instance URL, OAuth Client ID, Secret)
-→ User logs in on their SearchUnify instance (SSO supported)
-→ "Login Successful" page → user returns to Claude
-→ All tools work normally
+→ User clicks the link → browser opens the connection form
+→ User fills in: Instance URL, Search Client UID, OAuth Client ID, OAuth Client Secret
+→ User is redirected to their SearchUnify login page (SSO supported)
+→ After login → "Login Successful" page in browser
+→ User returns to Claude → all tools are now available
 ```
 
 #### Prerequisites
 
 - The MCP server must have `OAUTH_ENCRYPTION_KEY` and `MCP_ISSUER_URL` set (same as Integration 4).
-- An OAuth client must be registered in your SearchUnify Admin with **both** the following redirect URIs allowed:
-  - `<MCP_ISSUER_URL>/su-callback` (e.g. `https://mcp.searchunify.com/su-callback`) — used by the standard OAuth flow
-  - The same URL is used for the tool-based flow; if testing locally, also add `http://localhost:<port>/su-callback`
+- An OAuth client must be registered in your SearchUnify Admin with `<MCP_ISSUER_URL>/su-callback` as an allowed redirect URI (e.g. `https://mcp.searchunify.com/su-callback`).
 
-> **Local testing note:** If the MCP server's `su-callback` URL is not registered in the SU OAuth client, SU will redirect to its own dashboard after login instead of returning to the MCP server. Always register the exact callback URL for each environment.
+> **Note:** If the SU OAuth client does not have the MCP server's `/su-callback` URL registered, SU will redirect to its own dashboard after login instead of completing the connection. Always register the exact callback URL for each environment (including localhost for local testing).
 
 #### Claude Desktop Configuration
 
@@ -571,11 +572,9 @@ Claude Desktop → connects to /mcp-connect (no OAuth, no browser)
 }
 ```
 
-> **Note:** Use `/mcp-connect` instead of `/6565/mcp` or `/7777/mcp`. The server assigns a session ID automatically — no OAuth browser flow is triggered.
-
 #### Usage
 
-On first use, Claude will automatically call the `login` tool and display the connection link. Click it, fill in the form (instance URL, OAuth Client ID, OAuth Client Secret), log in, and return to Claude. All tools are then available for the duration of the session (1 hour).
+On first use, Claude will automatically call the `login` tool and display the connection link. Click it, complete the form in your browser, log in, and return to Claude. All tools are then available for the duration of the session (1 hour).
 
 If the session expires, call the `login` tool again to reconnect.
 
@@ -714,6 +713,19 @@ su-mcp/
 ---
 
 ## Changelog
+
+### v2.0.0
+- Full OAuth 2.0 proxy flow with PKCE for Claude public directory listing (`/mcp` endpoint)
+- Tool-based login flow (`/mcp-connect`) — user clicks a link in chat to authenticate via browser
+- AES-256-GCM encrypted token storage with Redis (optional) or in-memory fallback
+- Dynamic client registration and auto-re-registration on unknown clients
+- Refresh token rotation with 24-day TTL
+- Rate limiting on auth and MCP endpoints
+- Security hardening: CSP headers, HSTS, PKCE validation, bearer token verification
+- OAuth configuration form with inline validation, SearchUnify branding, and setup docs link
+- Tool call logging with caller IP, endpoint, SU instance URL, and OAuth client ID
+- Multi-platform Docker image (`linux/amd64`, `linux/arm64`)
+- Server version now read from `package.json` (shows correctly in all transport modes)
 
 ### v1.3.0
 - Added `/mcp-connect` endpoint — tool-based login for environments where Claude Desktop cannot auto-open a browser

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "author": "Ashish Prasher <ashish.prasher@grazitti.com>",
   "license": "ISC",
-  "description": "Searchunify MCP to use SearchUnify Search",
+  "description": "MCP server for SearchUnify enterprise search — integrates with Claude and other AI assistants via OAuth, tool-based login, or API key auth",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",
     "express": "^5.2.1",

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -71,9 +71,7 @@ class SUMcpOAuthProvider {
    * which redirects to SU's login.
    */
   async authorize(client, params, res) {
-    // Store the OAuth session params in Redis so we can retrieve them after SU callback
     const sessionId = generateToken();
-    console.error(`[OAuth] authorize() — created sessionId: ${sessionId.slice(0, 8)}... clientId: ${client.client_id?.slice(0, 8)}...`);
     await this.store.saveOAuthSession(sessionId, {
       clientId: client.client_id,
       redirectUri: params.redirectUri,
@@ -81,7 +79,6 @@ class SUMcpOAuthProvider {
       state: params.state || "",
       scopes: params.scopes || [],
     });
-    console.error(`[OAuth] authorize() — session saved to Redis key: su-mcp:session:${sessionId.slice(0, 8)}...`);
 
     const basePath = new URL(this.mcpCallbackUrl).pathname.replace(/\/su-callback$/, "");
     const nonce = crypto.randomBytes(16).toString("base64");
@@ -119,7 +116,6 @@ class SUMcpOAuthProvider {
    * @param {string} uid - Search Client UID (used in search/analytics API calls)
    */
   async handleAuthorizeStart(sessionId, instanceUrl, suClientId, suClientSecret, uid) {
-    console.error(`[OAuth] handleAuthorizeStart() — sessionId: ${sessionId.slice(0, 8)}... instance: ${instanceUrl}`);
     return this._handleAuthorizeStartInternal(sessionId, instanceUrl, suClientId, suClientSecret, uid);
   }
 
@@ -178,29 +174,22 @@ class SUMcpOAuthProvider {
    * SU redirects here with ?code=SU_AUTH_CODE&state=SESSION_ID
    */
   async handleSuCallback(suAuthCode, sessionId) {
-    console.error(`[OAuth] handleSuCallback() — state/sessionId received: ${sessionId?.slice(0, 8)}... (len: ${sessionId?.length})`);
     const session = await this.store.getOAuthSession(sessionId);
-    console.error(`[OAuth] handleSuCallback() — session lookup result: ${session ? "FOUND" : "NOT FOUND"}`);
     if (!session) {
       throw new Error("Invalid or expired OAuth session");
     }
 
-    // Exchange SU auth code for SU access token using the per-session SU client creds
-    console.error(`[OAuth] handleSuCallback() — exchanging SU code at: ${session.instanceUrl}/oauth/token/ clientId: ${session.suClientId?.slice(0, 8)}...`);
     let suTokens;
     try {
       suTokens = await this._exchangeSuCode(
         session.instanceUrl, suAuthCode, session.suClientId, session.suClientSecret
       );
-      console.error(`[OAuth] handleSuCallback() — SU token exchange SUCCESS, has access_token: ${!!(suTokens.access_token || suTokens.accessToken)}`);
     } catch (err) {
-      console.error(`[OAuth] handleSuCallback() — SU token exchange FAILED: ${err.message}`);
+      console.error(`[OAuth] SU token exchange failed: ${err.message}`);
       throw err;
     }
 
-    // Generate MCP auth code and store it with the SU tokens
     const mcpAuthCode = generateToken();
-    console.error(`[OAuth] handleSuCallback() — MCP auth code generated, redirecting to: ${session.redirectUri?.slice(0, 30)}...`);
     await this.store.saveAuthCode(mcpAuthCode, {
       clientId: session.clientId,
       redirectUri: session.redirectUri,
@@ -284,13 +273,10 @@ class SUMcpOAuthProvider {
    * Returns the stored code_challenge for a given authorization code.
    */
   async challengeForAuthorizationCode(client, authorizationCode) {
-    console.error(`[OAuth] challengeForAuthorizationCode() — code: ${authorizationCode?.slice(0, 16)}...`);
     const codeData = await this.store.getAuthCode(authorizationCode);
     if (!codeData) {
-      console.error(`[OAuth] challengeForAuthorizationCode() — NOT FOUND (stale or expired code)`);
       throw new Error("Invalid or expired authorization code");
     }
-    console.error(`[OAuth] challengeForAuthorizationCode() — FOUND`);
     return codeData.codeChallenge;
   }
 
@@ -299,9 +285,7 @@ class SUMcpOAuthProvider {
    * The SDK handles PKCE validation before calling this.
    */
   async exchangeAuthorizationCode(client, authorizationCode) {
-    console.error(`[OAuth] exchangeAuthorizationCode() — code: ${authorizationCode?.slice(0, 8)}...`);
     const codeData = await this.store.getAuthCode(authorizationCode);
-    console.error(`[OAuth] exchangeAuthorizationCode() — authCode lookup: ${codeData ? "FOUND" : "NOT FOUND"}`);
     if (!codeData) {
       throw new Error("Invalid or expired authorization code");
     }
@@ -325,7 +309,6 @@ class SUMcpOAuthProvider {
       suTokens: codeData.suTokens,
     });
 
-    console.error(`[OAuth] exchangeAuthorizationCode() — access token stored: ${accessToken.slice(0, 8)}...`);
     return {
       access_token: accessToken,
       token_type: "bearer",
@@ -338,10 +321,8 @@ class SUMcpOAuthProvider {
    * Exchanges a refresh token for a new access token.
    */
   async exchangeRefreshToken(client, refreshToken, scopes) {
-    console.error(`[OAuth] exchangeRefreshToken() — client: ${client.client_id?.slice(0, 8)}... token: ${refreshToken?.slice(0, 8)}...`);
     const refreshData = await this.store.getRefreshToken(refreshToken);
     if (!refreshData) {
-      console.error(`[OAuth] exchangeRefreshToken() — refresh token NOT FOUND (expired or already rotated)`);
       throw new Error("Invalid or expired refresh token");
     }
 
@@ -364,7 +345,6 @@ class SUMcpOAuthProvider {
       suTokens: refreshData.suTokens,
     });
 
-    console.error(`[OAuth] exchangeRefreshToken() — new access token: ${accessToken.slice(0, 8)}... new refresh token: ${newRefreshToken.slice(0, 8)}... (old refresh token rotated)`);
     return {
       access_token: accessToken,
       token_type: "bearer",
@@ -377,15 +357,10 @@ class SUMcpOAuthProvider {
    * Verifies an access token and returns auth info.
    */
   async verifyAccessToken(token) {
-    console.error(`[OAuth] verifyAccessToken() — checking token: ${token?.slice(0, 8)}...`);
     const tokenData = await this.store.getAccessToken(token);
     if (!tokenData) {
-      console.error(`[OAuth] verifyAccessToken() — token NOT FOUND: ${token?.slice(0, 8)}...`);
-      // Throw InvalidTokenError so SDK returns 401 (not 500) and mcp-remote can retry OAuth
       throw new InvalidTokenError("Invalid or expired access token");
     }
-
-    console.error(`[OAuth] verifyAccessToken() — OK, client: ${tokenData.clientId?.slice(0, 8)}...`);
     return {
       token,
       clientId: tokenData.clientId,

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -71,6 +71,7 @@ class SUMcpOAuthProvider {
    * which redirects to SU's login.
    */
   async authorize(client, params, res) {
+    console.error(`[OAuth] authorize — showing connection form`);
     const sessionId = generateToken();
     await this.store.saveOAuthSession(sessionId, {
       clientId: client.client_id,
@@ -116,6 +117,7 @@ class SUMcpOAuthProvider {
    * @param {string} uid - Search Client UID (used in search/analytics API calls)
    */
   async handleAuthorizeStart(sessionId, instanceUrl, suClientId, suClientSecret, uid) {
+    console.error(`[OAuth] authorize/start — redirecting to SU login: ${instanceUrl}`);
     return this._handleAuthorizeStartInternal(sessionId, instanceUrl, suClientId, suClientSecret, uid);
   }
 
@@ -185,9 +187,10 @@ class SUMcpOAuthProvider {
         session.instanceUrl, suAuthCode, session.suClientId, session.suClientSecret
       );
     } catch (err) {
-      console.error(`[OAuth] SU token exchange failed: ${err.message}`);
+      console.error(`[OAuth] su-callback — SU token exchange failed: ${err.message}`);
       throw err;
     }
+    console.error(`[OAuth] su-callback — login completed for: ${session.instanceUrl}`);
 
     const mcpAuthCode = generateToken();
     await this.store.saveAuthCode(mcpAuthCode, {
@@ -287,8 +290,10 @@ class SUMcpOAuthProvider {
   async exchangeAuthorizationCode(client, authorizationCode) {
     const codeData = await this.store.getAuthCode(authorizationCode);
     if (!codeData) {
+      console.error(`[OAuth] token exchange failed — invalid or expired auth code`);
       throw new Error("Invalid or expired authorization code");
     }
+    console.error(`[OAuth] token exchange — access token issued for client: ${client.client_id?.slice(0, 8)}...`);
 
     await this.store.deleteAuthCode(authorizationCode);
 
@@ -323,8 +328,10 @@ class SUMcpOAuthProvider {
   async exchangeRefreshToken(client, refreshToken, scopes) {
     const refreshData = await this.store.getRefreshToken(refreshToken);
     if (!refreshData) {
+      console.error(`[OAuth] token refresh failed — invalid or expired refresh token for client: ${client.client_id?.slice(0, 8)}...`);
       throw new Error("Invalid or expired refresh token");
     }
+    console.error(`[OAuth] token refresh — new access token issued for client: ${client.client_id?.slice(0, 8)}...`);
 
     const accessToken = generateToken();
     const newRefreshToken = generateToken();

--- a/src/auth/store.js
+++ b/src/auth/store.js
@@ -149,7 +149,8 @@ class RedisStore {
   async connect() {
     try {
       const Redis = (await import("ioredis")).default;
-      this.redis = new Redis(this._redisUrl || process.env.REDIS_URL || "redis://localhost:6379", {
+      const DEFAULT_REDIS_URL = "redis://localhost:6379";
+      this.redis = new Redis(this._redisUrl || DEFAULT_REDIS_URL, {
         maxRetriesPerRequest: 3,
         retryStrategy(times) {
           if (times > 5) return null;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { AsyncLocalStorage } from "node:async_hooks";
 import express from "express";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -57,7 +56,6 @@ async function runStdio(creds) {
   console.error("SearchUnify MCP Server running on stdio");
 }
 
-const httpCredsStorage = new AsyncLocalStorage();
 
 /**
  * Returns the "Login Successful" HTML page shown after SU authentication.
@@ -470,16 +468,6 @@ function startServer(app, port, oauthEnabled) {
 }
 
 async function runHttp(creds, port) {
-  const server = createMcpServer();
-  const getCreds = () => httpCredsStorage.getStore() ?? creds;
-  await initializeTools({ server, creds, getCreds });
-
-  // Stateless mode (no sessionIdGenerator) so multiple clients can connect and initialize.
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-  });
-  await server.connect(transport);
-
   let oauthEnabled = isOAuthEnabled();
   let oauthProvider;
 

--- a/src/index.js
+++ b/src/index.js
@@ -493,6 +493,16 @@ async function runHttp(creds, port) {
   // Note: do NOT use app.use(express.json()) globally — it consumes the request body
   // before StreamableHTTPServerTransport can read it. Only apply JSON parsing on specific routes.
 
+  // CORS — required for browser-based clients (Claude.ai web, Cowork)
+  app.use((req, res, next) => {
+    res.set("Access-Control-Allow-Origin", "*");
+    res.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE");
+    res.set("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id, Accept");
+    res.set("Access-Control-Expose-Headers", "mcp-session-id");
+    if (req.method === "OPTIONS") return res.status(204).end();
+    next();
+  });
+
   // Security headers for all responses (applied regardless of OAuth mode)
   app.use((req, res, next) => {
     res.set({

--- a/src/su-core/su-core-analytics.js
+++ b/src/su-core/su-core-analytics.js
@@ -42,6 +42,11 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         "Sort field: for search-classification reports use count (query frequency). For sessionListTable use click, search, case, page_view, support, end_date, or start_date. For sessionDetails (session log) use the same except page_view when not applicable — if you pass count here it is sent as click for classification reports only."
       ),
     sortType: z.enum(["asc", "desc"]).optional().describe("sort direction; defaults to desc where applicable"),
+  }, {
+    title: "Analytics",
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
   }, async ({ reportType, startDate, endDate, count, sessionId, pageNumber, startIndex, sortByField, sortType }) => {
     const credsForRequest = await c();
     if (!credsForRequest) return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };

--- a/src/su-core/su-core-analytics.js
+++ b/src/su-core/su-core-analytics.js
@@ -29,8 +29,8 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
       .describe(
         "Which report to fetch. Tile APIs: tileDataContent (content gap); tileDataMetrics1 (visitors = session count, searchUsers, uniqueUsersByDevice, email metrics); tileDataMetrics2 (search volume, results split, clicks, cases). Classification: searchQueryWith* / getAllSearchQuery. Conversion: getAllSearchConversion, averageClickPosition. Sessions: sessionDetails, sessionListTable."
       ),
-    startDate: z.string().describe("start date of the report"),
-    endDate: z.string().describe("end date of the report"),
+    startDate: z.string().describe("Start date of the report in YYYY-MM-DD format"),
+    endDate: z.string().describe("End date of the report in YYYY-MM-DD format"),
     count: z.number().min(1).max(500).describe("number of records to be fetched (1-500)"),
     sessionId: z.string().optional().describe("optional session cookie filter for sessionDetails (GET /api/v2/session/log/all) and sessionListTable (GET /api/v2/session/list/table)"),
     pageNumber: z.number().min(1).max(10).optional().describe("page number for the 4 search classification reports (max 10 in MCP)"),

--- a/src/su-core/su-core-search-clients.js
+++ b/src/su-core/su-core-search-clients.js
@@ -8,6 +8,7 @@ const initializeSearchClientsTools = async ({ server, creds, getCreds }) => {
     "Get list of all search clients configured in the SearchUnify instance. Returns minimal info: id, name, and uid for each search client.",
     {},
     {
+      title: "Get Search Clients",
       readOnlyHint: true,
       destructiveHint: false,
       openWorldHint: true,

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -9,12 +9,12 @@ const aggregationSchema = z.object({
 const initializeSearchTools = async ({ server, creds, getCreds }) => {
   const credsForRequest = async () => (getCreds ? await getCreds() : creds);
   server.tool("search", "Get relevant search results for a search query using SearchUnify. Optionally pass aggregations (facets) from get-filter-options to filter results.", {
-    searchString: z.string().min(3).max(100).describe("search query, its a string can be a single word or a sentence"),
+    searchString: z.string().min(3).max(100).describe("Search query (3–100 characters)"),
     aggregations: z.array(aggregationSchema).optional().describe("optional list of facet filters (e.g. from get-filter-options) to narrow results by category, source, etc."),
     page: z.number().int().min(1).max(100).optional().describe("page number for pagination, starts from 1"),
     pageSize: z.number().int().min(1).max(100).optional().describe("number of results per page, default is 10"),
     sortBy: z.enum(["_score", "post_time"]).optional().describe("field to sort results by, e.g. _score or post_time"),
-    versionResults: z.boolean().default(false).optional().describe("This field speicifies whether to use versioning or not. Default value is true."),
+    versionResults: z.boolean().default(false).optional().describe("Whether to use versioning for results. Defaults to false."),
     // sortOrder: z.enum(["asc", "desc"]).optional().describe("sort order for results, asc or desc"),
   }, {
     title: "Search",
@@ -46,8 +46,6 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       requestParams.aggregations = aggregations.map((a) => ({ type: a.type, filter: [a.filter] }));
     }
 
-    console.error("[INFO] - Request parameters being sent to search API : ", JSON.stringify(requestParams));
-    
     const searchResponse = await Search.getSearchResults(requestParams);
 
     if(!searchResponse?.data){
@@ -57,11 +55,8 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       }
     }
     const gptActive = searchResponse?.data?.searchClientSettings?.gptConfig?.gptActive;
-    console.error('[INFO] - gptActive',gptActive);
     if(gptActive){
       const contexts = searchResponse.data.searchClientSettings.gptConfig.gptContext.split("_SULLM_");
-
-      console.error('[INFO] - Number of gpt contexts received from Search: ', contexts?.length);
 
       for(let i = 0; i < contexts.length; i++) {
         if(searchResponse.data.searchClientSettings.gptConfig.gptLinks[i - 1]){
@@ -71,8 +66,6 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       return formatForClaude(searchResponse.data.searchClientSettings.gptConfig.gptLinks); 
     } else {
       const contexts = [];
-      
-      console.error('[INFO] - Number of search hits received in response: ', searchResponse.data?.result?.hits?.length);
       
       for(let i = 0; i < searchResponse.data?.result?.hits?.length; i++){
         contexts.push({

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -17,6 +17,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
     versionResults: z.boolean().default(false).optional().describe("This field speicifies whether to use versioning or not. Default value is true."),
     // sortOrder: z.enum(["asc", "desc"]).optional().describe("sort order for results, asc or desc"),
   }, {
+    title: "Search",
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: true,
@@ -94,6 +95,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       aggregations: z.array(aggregationSchema).optional().describe("optional list of current filters to get filter options in context of filtered results"),
     },
     {
+      title: "Get Filter Options",
       readOnlyHint: true,
       destructiveHint: false,
       openWorldHint: true,

--- a/src/tools.js
+++ b/src/tools.js
@@ -11,6 +11,12 @@ export const initializeTools = async ({ server, creds, getCreds, mcpSessionId, o
       "login",
       "ALWAYS call this tool first before any other SearchUnify tool, and whenever any tool returns a not-authenticated error. Returns a login link for the user — present it in the chat so they can click it. Never tell the user to go to settings or reconnect manually.",
       {},
+      {
+        title: "Login",
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
       async () => {
         const loginUrl = `${base}/mcp-connect/login?s=${encodeURIComponent(mcpSessionId)}`;
         return {


### PR DESCRIPTION
- oauth-provider.js: remove 15+ debug console.error calls that logged partial tokens, session IDs, and internal flow state; keep only genuine error logs (SU token exchange failure)
- index.js: remove dead McpServer + StreamableHTTPServerTransport created in runHttp() that was never used (stateless mode creates per-request instances); remove unused AsyncLocalStorage import and httpCredsStorage
- store.js: extract hardcoded redis://localhost:6379 into DEFAULT_REDIS_URL constant
- package.json: update description to reflect v2.0.0 capabilities
- README: fix Docker tag 1.1.0 → 2.0.0; add v2.0.0 changelog entry; rewrite Integration 5 — browser IS required (manual click, not auto-open)