### PR TITLE
feat: extract user email from SU OAuth token response

### DIFF
--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -165,6 +165,7 @@ class SUMcpOAuthProvider {
       suClientId: session.suClientId,
       suClientSecret: session.suClientSecret,
       uid: session.uid,
+      email: suTokens._email ?? null,
     });
 
     await this.store.deleteOAuthSession(sessionId);
@@ -205,6 +206,7 @@ class SUMcpOAuthProvider {
         suClientId: session.suClientId,
         suClientSecret: session.suClientSecret,
         uid: session.uid,
+        email: suTokens._email ?? null,
       },
     });
 
@@ -255,6 +257,7 @@ class SUMcpOAuthProvider {
             try {
               const parsed = JSON.parse(data);
               if (parsed.access_token || parsed.accessToken) {
+                parsed._email = parsed.user?.username ?? null;
                 resolve(parsed);
               } else {
                 reject(new Error(`SU token exchange failed: ${data}`));

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -38,7 +38,8 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       resultsPerPage: effectivePageSize,
       versionResults: !!versionResults,
       ...(sortBy ? { sortby: sortBy } : {}),
-      orderBy: 'desc'
+      orderBy: 'desc',
+      ...(c.config.email ? { email: c.config.email } : {}),
    };
     
     if (aggregations?.length) {
@@ -91,7 +92,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       const c = await credsForRequest();
       if (!c) return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
       const Search = c.suRestClient.Search();
-      const requestParams = { uid: c.config.uid, searchString };
+      const requestParams = { uid: c.config.uid, searchString, ...(c.config.email ? { email: c.config.email } : {}) };
       if (aggregations?.length) {
         requestParams.aggregations = aggregations.map((a) => ({ type: a.type, filter: [a.filter] }));
       }

--- a/src/validations.js
+++ b/src/validations.js
@@ -113,7 +113,7 @@ function getCredsFromHeaders(headers) {
  * @param {Object} suTokens - { accessToken, refreshToken, instanceUrl }
  */
 function buildCredsFromSuToken(suTokens) {
-  const { instanceUrl, suClientId, suClientSecret, uid } = suTokens;
+  const { instanceUrl, suClientId, suClientSecret, uid, email } = suTokens;
   const suRestClient = new SearchUnifyRestClient({
     instance: instanceUrl,
     timeout: parseInt(process.env.SU_TIMEOUT || "60000", 10),
@@ -123,7 +123,7 @@ function buildCredsFromSuToken(suTokens) {
       clientSecret: suClientSecret,
     },
   });
-  return { suRestClient, config: { instance: instanceUrl, uid } };
+  return { suRestClient, config: { instance: instanceUrl, uid, email: email ?? null } };
 }
 
 export { validateCreds, getCredsFromHeaders, buildCredsFromSuToken };


### PR DESCRIPTION
multi-tenant-auth's /oauth/token/ returns token.user.username (aliased from user_email) in the response body. Extract it in _exchangeSuCode and thread it through both OAuth flows (standard + tool-based) so it lands in c.config.email for all tool handlers.

No behaviour change for existing callers — email is null when absent.