### PR TITLE
Feat/ecosystem uid detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,62 @@ npm test
 
 Runs validation and module import tests for all tools.
 
+### Integration 6: `/mcp-api` — Shared Credentials (No Per-User Login)
+
+Use this integration when **all users should share the same identity** — for example, a Microsoft Copilot / Power Platform connector where an admin configures credentials once and every user benefits automatically with no login prompt.
+
+```
+Admin configures connector once with searchunify-* headers
+        ↓
+All users connect via the Copilot agent
+        ↓
+MCP works immediately — no form, no browser redirect, no per-user auth
+```
+
+**When to use vs `/mcp` (OAuth):**
+
+| | `/mcp` OAuth | `/mcp-api` Header Auth |
+|--|-------------|------------------------|
+| Per-user identity | Yes — each user has their own SU token | No — all users share one identity |
+| Personalized results | Yes (if SU supports it) | No |
+| Setup | Each user logs in once | Admin configures once |
+| Best for | Claude, Claude Desktop | Copilot, Power Platform, server-to-server |
+
+#### Microsoft Copilot / Power Platform Setup
+
+In your custom connector definition, add these static headers (configured once by the admin):
+
+| Header | Value |
+|--------|-------|
+| `searchunify-instance` | `https://your-instance.searchunify.com` |
+| `searchunify-uid` | Your Search Client UID |
+| `searchunify-auth-type` | `apiKey` |
+| `searchunify-api-key` | Your API key |
+
+MCP endpoint URL: `https://mcp.searchunify.com/mcp-api`
+
+#### Claude Desktop / mcp-remote Setup
+
+```json
+{
+  "mcpServers": {
+    "su-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.searchunify.com/mcp-api",
+        "--header", "searchunify-instance:https://your-instance.searchunify.com",
+        "--header", "searchunify-uid:<search_client_uid>",
+        "--header", "searchunify-auth-type:apiKey",
+        "--header", "searchunify-api-key:<your_api_key>"
+      ]
+    }
+  }
+}
+```
+
+> The same header reference from [Integration 2](#integration-2-mcp-remote--remote-http-with-header-auth) applies — all `searchunify-*` headers are supported including `searchunify-ecosystem-id` and `searchunify-timeout`.
+
 ---
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ MCP_TRANSPORT=both node src/index.js
 
 The simplest way to get started. When you add the MCP server from Claude's directory, a browser-based form opens automatically to collect your credentials. Authentication is handled via OAuth 2.0 using a proxy flow — the MCP server delegates login to your SearchUnify instance. No API keys or passwords are stored in Claude.
 
+> **Ecosystem UID support:** The connection form accepts both search client UIDs and ecosystem UIDs in the UID field. The server automatically detects which type it is and routes API calls accordingly. If the UID is not found in your SearchUnify instance, a clear error page is shown during login.
+
 > **Self-hosting:** If you are running your own instance of su-mcp (not using `mcp.searchunify.com`), you must also set `OAUTH_ENCRYPTION_KEY` (64-char hex, generate with `openssl rand -hex 32`), `MCP_ISSUER_URL` (public HTTPS URL of your server), and optionally `REDIS_URL` for persistent token storage before starting the server.
 
 **OAuth proxy flow:**
@@ -340,7 +342,8 @@ All header names use the `searchunify-` prefix (lowercase):
 | Header | Required | Description |
 |--------|----------|-------------|
 | `searchunify-instance` | Yes | Your SearchUnify instance URL (e.g. `https://your-instance.searchunify.com`). |
-| `searchunify-uid` | Yes | Search Client UID. |
+| `searchunify-uid` | Yes | Search Client UID. Also used for tenancy routing when `searchunify-ecosystem-id` is set. |
+| `searchunify-ecosystem-id` | No | Ecosystem UUID. When set, analytics and search calls scope to the ecosystem instead of the search client. Pass alongside `searchunify-uid` (both are used). |
 | `searchunify-auth-type` | Yes | Authentication method: `apiKey`, `password`, or `clientCredentials`. |
 | `searchunify-timeout` | No | Per-request SDK timeout in milliseconds. Defaults to `60000`. Use **120000** or higher for `leadershipCostSavingsExplicitDeflection` on large tenants if you see Axios timeout errors. Also set in `creds.json` as `"timeout": 120000` or `SU_TIMEOUT` for OAuth flows. |
 
@@ -497,6 +500,21 @@ Choose one of the following formats based on your authentication method:
   "uid": "<search_client_uid>"
 }
 ```
+
+**Ecosystem UID configuration** (use when your UID is an ecosystem UUID):
+
+```json
+{
+  "instance": "<searchunify_instance_url>",
+  "timeout": 60000,
+  "authType": "apiKey",
+  "apiKey": "<your_api_key>",
+  "uid": "<search_client_or_ecosystem_uid>",
+  "ecoSystemId": "<ecosystem_uid>"
+}
+```
+
+When `ecoSystemId` is present, analytics and search calls automatically scope to the ecosystem. `uid` is still required for tenancy routing. To find the correct UIDs, go to your SearchUnify admin panel → **Search Clients** or **Ecosystems**.
 
 #### Step 2 — Configure Claude Desktop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "searchunify-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "searchunify-mcp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,15 @@
 {
   "name": "searchunify-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "src/index.js",
-  "keywords": ["mcp", "mcp-server", "claude", "searchunify", "search", "enterprise-search"],
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "claude",
+    "searchunify",
+    "search",
+    "enterprise-search"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/searchunify/su-mcp.git"

--- a/scripts/test-mcp-client.js
+++ b/scripts/test-mcp-client.js
@@ -1,16 +1,28 @@
 #!/usr/bin/env node
 /**
- * Boilerplate MCP client to verify the SearchUnify MCP server (stdio or HTTP).
+ * Boilerplate MCP client to verify the SearchUnify MCP server.
  *
  * Usage:
- *   # Test stdio (spawns server; requires creds at src/input/creds.json)
+ *   # Integration 3: stdio (spawns server locally; requires creds at src/input/creds.json)
  *   node scripts/test-mcp-client.js stdio
  *
- *   # Test HTTP (server must already be running, e.g. MCP_TRANSPORT=http node src/index.js)
+ *   # Integration 2: root / with header auth
+ *   MCP_HTTP_URL=https://mcp.searchunify.com/ \
+ *   SU_INSTANCE=https://acme.searchunify.com SU_UID=<uid> SU_AUTH_TYPE=apiKey SU_API_KEY=<key> \
  *   node scripts/test-mcp-client.js http
  *
- *   # HTTP with custom URL
- *   MCP_HTTP_URL=http://localhost:4000 node scripts/test-mcp-client.js http
+ *   # Integration 6: /mcp-api with header auth
+ *   MCP_HTTP_URL=https://mcp.searchunify.com/mcp-api \
+ *   SU_INSTANCE=https://acme.searchunify.com SU_UID=<uid> SU_AUTH_TYPE=apiKey SU_API_KEY=<key> \
+ *   node scripts/test-mcp-client.js http
+ *
+ *   # Integration 1: /mcp OAuth — requires a Bearer token obtained via the OAuth browser flow
+ *   MCP_HTTP_URL=https://mcp.searchunify.com/mcp MCP_BEARER_TOKEN=<token> \
+ *   node scripts/test-mcp-client.js oauth
+ *
+ *   # Integration 4: /mcp-connect — connects, calls login tool, prints URL for manual completion
+ *   MCP_HTTP_URL=https://mcp.searchunify.com/mcp-connect \
+ *   node scripts/test-mcp-client.js mcp-connect
  */
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -25,41 +37,73 @@ const projectRoot = join(__dirname, "..");
 const transportType = (process.argv[2] || process.env.MCP_TEST_TRANSPORT || "stdio").toLowerCase();
 const httpUrl = process.env.MCP_HTTP_URL || "http://localhost:3000";
 
-async function runTest() {
-  console.log(`\n--- SearchUnify MCP client test (transport: ${transportType}) ---\n`);
-
-  let transport;
+async function buildTransport() {
   if (transportType === "stdio") {
-    transport = new StdioClientTransport({
+    console.log("Spawning server via stdio (cwd: %s)...", projectRoot);
+    return new StdioClientTransport({
       command: "node",
       args: ["src/index.js"],
       cwd: projectRoot,
       env: { ...process.env, MCP_TRANSPORT: "stdio" },
     });
-    console.log("Spawning server via stdio (cwd: %s)...", projectRoot);
-  } else if (transportType === "http") {
-    // Build optional searchunify-* headers from env vars (for /mcp-api header-based auth)
-    const suHeaders = {};
-    if (process.env.SU_INSTANCE)   suHeaders["searchunify-instance"]    = process.env.SU_INSTANCE;
-    if (process.env.SU_UID)        suHeaders["searchunify-uid"]         = process.env.SU_UID;
-    if (process.env.SU_AUTH_TYPE)  suHeaders["searchunify-auth-type"]   = process.env.SU_AUTH_TYPE;
-    if (process.env.SU_API_KEY)    suHeaders["searchunify-api-key"]     = process.env.SU_API_KEY;
-    const transportOpts = Object.keys(suHeaders).length ? { requestInit: { headers: suHeaders } } : {};
-    transport = new StreamableHTTPClientTransport(new URL(httpUrl), transportOpts);
-    console.log("Connecting to HTTP server at %s...", httpUrl);
-  } else {
-    console.error("Unknown transport: %s. Use 'stdio' or 'http'.", transportType);
-    process.exit(1);
   }
 
+  if (transportType === "http") {
+    // Integration 2 (root /) and Integration 6 (/mcp-api) — header-based auth
+    const suHeaders = {};
+    if (process.env.SU_INSTANCE)   suHeaders["searchunify-instance"]  = process.env.SU_INSTANCE;
+    if (process.env.SU_UID)        suHeaders["searchunify-uid"]       = process.env.SU_UID;
+    if (process.env.SU_AUTH_TYPE)  suHeaders["searchunify-auth-type"] = process.env.SU_AUTH_TYPE;
+    if (process.env.SU_API_KEY)    suHeaders["searchunify-api-key"]   = process.env.SU_API_KEY;
+    const opts = Object.keys(suHeaders).length ? { requestInit: { headers: suHeaders } } : {};
+    console.log("Connecting to %s (header auth)...", httpUrl);
+    return new StreamableHTTPClientTransport(new URL(httpUrl), opts);
+  }
+
+  if (transportType === "oauth") {
+    // Integration 1: /mcp — Bearer token from OAuth flow
+    const token = process.env.MCP_BEARER_TOKEN;
+    if (!token) {
+      console.error([
+        "MCP_BEARER_TOKEN is required for oauth transport.",
+        "",
+        "To get a token:",
+        "  1. Add https://mcp.searchunify.com/mcp to Claude or use mcp-remote",
+        "  2. Complete the OAuth connection form and SU login",
+        "  3. Extract the Bearer token from the Authorization header of any MCP request",
+        "     (visible in mcp-remote debug output or network inspector)",
+        "",
+        "Then re-run:",
+        "  MCP_HTTP_URL=https://mcp.searchunify.com/mcp MCP_BEARER_TOKEN=<token> \\",
+        "  node scripts/test-mcp-client.js oauth",
+      ].join("\n"));
+      process.exit(1);
+    }
+    console.log("Connecting to %s (OAuth Bearer token)...", httpUrl);
+    return new StreamableHTTPClientTransport(new URL(httpUrl), {
+      requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    });
+  }
+
+  if (transportType === "mcp-connect") {
+    // Integration 4: /mcp-connect — stateful, tool-based login
+    console.log("Connecting to %s (mcp-connect, no auth)...", httpUrl);
+    return new StreamableHTTPClientTransport(new URL(httpUrl));
+  }
+
+  console.error("Unknown transport: %s. Use stdio | http | oauth | mcp-connect.", transportType);
+  process.exit(1);
+}
+
+async function runTest() {
+  console.log(`\n--- SearchUnify MCP client test (transport: ${transportType}) ---\n`);
+
+  const transport = await buildTransport();
   const client = new Client(
     { name: "searchunify-mcp-test-client", version: "1.0.0" },
     { capabilities: {} }
   );
-
-  client.onerror = (err) => {
-    console.error("Client error:", err);
-  };
+  client.onerror = (err) => console.error("Client error:", err);
 
   try {
     await client.connect(transport);
@@ -69,14 +113,31 @@ async function runTest() {
     const toolsResult = await client.listTools();
     console.log("Tools (%d):", toolsResult.tools?.length ?? 0);
     (toolsResult.tools || []).forEach((t) => {
-      console.log("  - %s: %s", t.name, t.description || "(no description)");
+      console.log("  - %s: %s", t.name, (t.description || "(no description)").slice(0, 80));
     });
 
     // 2. Ping
     await client.ping();
     console.log("\nPing: OK");
 
-    // 3. Optional: call "search" tool if present (minimal query to avoid heavy work)
+    // 3. mcp-connect: call login tool to get the connection URL, then stop
+    if (transportType === "mcp-connect") {
+      const loginTool = (toolsResult.tools || []).find((t) => t.name === "login");
+      if (loginTool) {
+        console.log("\nCalling 'login' tool to get connection URL...");
+        const loginResult = await client.callTool({ name: "login", arguments: {} });
+        const text = loginResult.content?.[0]?.text ?? JSON.stringify(loginResult.content);
+        console.log("Login tool response:\n", text);
+        console.log("\nOpen the URL above in a browser, fill in SU credentials, and complete login.");
+        console.log("After login, re-run with MCP_BEARER_TOKEN or use Claude Desktop to test tools.");
+      } else {
+        console.log("\nNo 'login' tool found on mcp-connect endpoint.");
+      }
+      console.log("\n--- mcp-connect connectivity check passed ---\n");
+      return;
+    }
+
+    // 4. Call search tool
     const searchTool = (toolsResult.tools || []).find((t) => t.name === "search");
     if (searchTool) {
       console.log("\nCalling tool 'search' with query 'content source salesforce'...");
@@ -90,14 +151,12 @@ async function runTest() {
         const text = first?.type === "text" ? first.text : JSON.stringify(first);
         console.log("First chunk preview:", text.slice(0, 200) + (text.length > 200 ? "..." : ""));
       }
-      if (callResult.isError) {
-        console.log("Tool reported error:", callResult.content);
-      }
+      if (callResult.isError) console.log("Tool reported error:", callResult.content);
     } else {
-      console.log("\nNo 'search' tool found; skipping tool call.");
+      console.log("\nNo 'search' tool found; skipping.");
     }
 
-    // 4. Optional: call "get-filter-options" tool if present
+    // 5. Call get-filter-options tool
     const filterTool = (toolsResult.tools || []).find((t) => t.name === "get-filter-options");
     if (filterTool) {
       console.log("\nCalling tool 'get-filter-options' with query 'search client salesforce'...");
@@ -111,9 +170,7 @@ async function runTest() {
         const text = first?.type === "text" ? first.text : JSON.stringify(first);
         console.log("Filter options preview:", text.slice(0, 400) + (text.length > 400 ? "..." : ""));
       }
-      if (filterResult.isError) {
-        console.log("Tool reported error:", filterResult.content);
-      }
+      if (filterResult.isError) console.log("Tool reported error:", filterResult.content);
     } else {
       console.log("\nNo 'get-filter-options' tool found; skipping.");
     }

--- a/scripts/test-mcp-client.js
+++ b/scripts/test-mcp-client.js
@@ -38,7 +38,14 @@ async function runTest() {
     });
     console.log("Spawning server via stdio (cwd: %s)...", projectRoot);
   } else if (transportType === "http") {
-    transport = new StreamableHTTPClientTransport(new URL(httpUrl));
+    // Build optional searchunify-* headers from env vars (for /mcp-api header-based auth)
+    const suHeaders = {};
+    if (process.env.SU_INSTANCE)   suHeaders["searchunify-instance"]    = process.env.SU_INSTANCE;
+    if (process.env.SU_UID)        suHeaders["searchunify-uid"]         = process.env.SU_UID;
+    if (process.env.SU_AUTH_TYPE)  suHeaders["searchunify-auth-type"]   = process.env.SU_AUTH_TYPE;
+    if (process.env.SU_API_KEY)    suHeaders["searchunify-api-key"]     = process.env.SU_API_KEY;
+    const transportOpts = Object.keys(suHeaders).length ? { requestInit: { headers: suHeaders } } : {};
+    transport = new StreamableHTTPClientTransport(new URL(httpUrl), transportOpts);
     console.log("Connecting to HTTP server at %s...", httpUrl);
   } else {
     console.error("Unknown transport: %s. Use 'stdio' or 'http'.", transportType);

--- a/src/auth/config-form.js
+++ b/src/auth/config-form.js
@@ -101,7 +101,7 @@ function getInstanceFormHTML({ formAction, sessionId, nonce = "" }) {
 
         <div class="fg">
           <label for="uid">Search Client UID<span class="req">*</span></label>
-          <input type="text" id="uid" name="uid" placeholder="e.g. abc123def456" autocomplete="off" spellcheck="false">
+          <input type="text" id="uid" name="uid" placeholder="e.g. 5f3a2b1c4d" autocomplete="off" spellcheck="false">
           <div class="ferr" id="e-uid"></div>
           <div class="help">Found in Admin → Search Clients</div>
         </div>
@@ -122,7 +122,7 @@ function getInstanceFormHTML({ formAction, sessionId, nonce = "" }) {
 
         <button type="submit" class="btn" id="btn">
           <div class="spin" id="spin"></div>
-          <span id="btntxt">Continue to Login</span>
+          <span id="btntxt">Connect to SearchUnify</span>
         </button>
       </form>
     </div>
@@ -210,7 +210,7 @@ function getInstanceFormHTML({ formAction, sessionId, nonce = "" }) {
     }
     function resetBtn() {
       btn.disabled = false; spin.style.display = 'none';
-      btntxt.textContent = 'Continue to Login';
+      btntxt.textContent = 'Connect to SearchUnify';
     }
 
     /* Blur / input listeners — real-time per-field feedback */
@@ -257,7 +257,7 @@ function getInstanceFormHTML({ formAction, sessionId, nonce = "" }) {
 
       /* POST via fetch — server returns { redirectUrl } or { error } */
       btn.disabled = true; spin.style.display = 'block';
-      btntxt.textContent = 'Connecting\u2026';
+      btntxt.textContent = 'Connecting to SearchUnify\u2026';
 
       var params = new URLSearchParams();
       params.append('session', document.querySelector('[name="session"]').value);

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -165,6 +165,7 @@ class SUMcpOAuthProvider {
       suClientId: session.suClientId,
       suClientSecret: session.suClientSecret,
       uid: session.uid,
+      email: suTokens._email ?? null,
     });
 
     await this.store.deleteOAuthSession(sessionId);
@@ -205,6 +206,7 @@ class SUMcpOAuthProvider {
         suClientId: session.suClientId,
         suClientSecret: session.suClientSecret,
         uid: session.uid,
+        email: suTokens._email ?? null,
       },
     });
 
@@ -255,6 +257,7 @@ class SUMcpOAuthProvider {
             try {
               const parsed = JSON.parse(data);
               if (parsed.access_token || parsed.accessToken) {
+                parsed._email = parsed.user?.username ?? null;
                 resolve(parsed);
               } else {
                 reject(new Error(`SU token exchange failed: ${data}`));

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -319,7 +319,8 @@ class SUMcpOAuthProvider {
             res.on("data", (chunk) => (data += chunk));
             res.on("end", () => {
               try {
-                const list = JSON.parse(data);
+                const parsed = JSON.parse(data);
+                const list = Array.isArray(parsed) ? parsed : parsed?.data;
                 if (!Array.isArray(list)) { resolve('error'); return; }
                 const match = list.find((item) => item.uid === uid);
                 if (!match) { resolve('unknown'); return; }

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -9,6 +9,8 @@ function generateToken() {
   return crypto.randomBytes(32).toString("hex");
 }
 
+const maskEmail = (e) => e ? `${e[0]}****@${e.split('@')[1]}` : '(none)';
+
 
 /**
  * OAuth clients store backed by Redis.
@@ -178,6 +180,7 @@ class SUMcpOAuthProvider {
       isEcosystem,
     });
 
+    console.error(`[OAuth] su-callback (tool) — login completed for: ${session.instanceUrl} user: ${maskEmail(suTokens._email)}`);
     await this.store.deleteOAuthSession(sessionId);
     return true;
   }
@@ -201,7 +204,7 @@ class SUMcpOAuthProvider {
       console.error(`[OAuth] su-callback — SU token exchange failed: ${err.message}`);
       throw err;
     }
-    console.error(`[OAuth] su-callback — login completed for: ${session.instanceUrl}`);
+    console.error(`[OAuth] su-callback — login completed for: ${session.instanceUrl} user: ${maskEmail(suTokens._email)}`);
 
     const rawAccessToken = suTokens.access_token || suTokens.accessToken;
     const uidType = await this._detectUidType(session.instanceUrl, rawAccessToken, session.uid);

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -280,6 +280,7 @@ class SUMcpOAuthProvider {
             try {
               const parsed = JSON.parse(data);
               if (parsed.access_token || parsed.accessToken) {
+                console.error(`[OAuth] SU token response keys: ${Object.keys(parsed).join(', ')}; user field: ${JSON.stringify(parsed.user)}`);
                 parsed._email = parsed.user?.username ?? null;
                 resolve(parsed);
               } else {

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -158,14 +158,24 @@ class SUMcpOAuthProvider {
       session.instanceUrl, suAuthCode, session.suClientId, session.suClientSecret
     );
 
+    const rawAccessToken = suTokens.access_token || suTokens.accessToken;
+    const uidType = await this._detectUidType(session.instanceUrl, rawAccessToken, session.uid);
+    if (uidType === 'unknown') {
+      const err = new Error(`"${session.uid}" was not found as a search client or ecosystem in this SearchUnify instance. Please check the UID and try again.`);
+      err.code = 'INVALID_UID';
+      throw err;
+    }
+    const isEcosystem = uidType === 'ecosystem';
+
     await this.store.saveToolSession(session.mcpSessionId, {
-      accessToken: suTokens.access_token || suTokens.accessToken,
+      accessToken: rawAccessToken,
       refreshToken: suTokens.refresh_token || suTokens.refreshToken,
       instanceUrl: session.instanceUrl,
       suClientId: session.suClientId,
       suClientSecret: session.suClientSecret,
       uid: session.uid,
       email: suTokens._email ?? null,
+      isEcosystem,
     });
 
     await this.store.deleteOAuthSession(sessionId);
@@ -193,6 +203,15 @@ class SUMcpOAuthProvider {
     }
     console.error(`[OAuth] su-callback — login completed for: ${session.instanceUrl}`);
 
+    const rawAccessToken = suTokens.access_token || suTokens.accessToken;
+    const uidType = await this._detectUidType(session.instanceUrl, rawAccessToken, session.uid);
+    if (uidType === 'unknown') {
+      const err = new Error(`"${session.uid}" was not found as a search client or ecosystem in this SearchUnify instance. Please check the UID and try again.`);
+      err.code = 'INVALID_UID';
+      throw err;
+    }
+    const isEcosystem = uidType === 'ecosystem';
+
     const mcpAuthCode = generateToken();
     await this.store.saveAuthCode(mcpAuthCode, {
       clientId: session.clientId,
@@ -200,13 +219,14 @@ class SUMcpOAuthProvider {
       codeChallenge: session.codeChallenge,
       scopes: session.scopes || [],
       suTokens: {
-        accessToken: suTokens.access_token || suTokens.accessToken,
+        accessToken: rawAccessToken,
         refreshToken: suTokens.refresh_token || suTokens.refreshToken,
         instanceUrl: session.instanceUrl,
         suClientId: session.suClientId,
         suClientSecret: session.suClientSecret,
         uid: session.uid,
         email: suTokens._email ?? null,
+        isEcosystem,
       },
     });
 
@@ -272,6 +292,50 @@ class SUMcpOAuthProvider {
       req.setTimeout(10000, () => { req.destroy(new Error("SU token exchange timed out")); });
       req.write(body);
       req.end();
+    });
+  }
+
+  /**
+   * Detects whether a uid belongs to a search_client or ecosystem by calling /api/v2/search-clients.
+   * Returns 'ecosystem' | 'search_client' | 'unknown' (uid not in list) | 'error' (network/timeout).
+   * 'unknown' → fail auth; 'error' → fail-open (treat as search_client).
+   */
+  async _detectUidType(instanceUrl, accessToken, uid) {
+    const url = `${instanceUrl}/api/v2/search-clients`;
+    return new Promise((resolve) => {
+      try {
+        const u = new URL(url);
+        const transport = u.protocol === "https:" ? https : http;
+        const req = transport.request(
+          {
+            method: "GET",
+            hostname: u.hostname,
+            port: u.port,
+            path: u.pathname,
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+          (res) => {
+            let data = "";
+            res.on("data", (chunk) => (data += chunk));
+            res.on("end", () => {
+              try {
+                const list = JSON.parse(data);
+                if (!Array.isArray(list)) { resolve('error'); return; }
+                const match = list.find((item) => item.uid === uid);
+                if (!match) { resolve('unknown'); return; }
+                resolve(match.type === 'ecosystem' ? 'ecosystem' : 'search_client');
+              } catch {
+                resolve('error');
+              }
+            });
+          }
+        );
+        req.on("error", () => resolve('error'));
+        req.setTimeout(10000, () => { req.destroy(); resolve('error'); });
+        req.end();
+      } catch {
+        resolve('error');
+      }
     });
   }
 

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import http from "node:http";
 import https from "node:https";
+import { log } from "../logger.js";
 import { createStore, ACCESS_TOKEN_TTL, REFRESH_TOKEN_TTL } from "./store.js";
 import { getInstanceFormHTML } from "./config-form.js";
 import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
@@ -73,7 +74,7 @@ class SUMcpOAuthProvider {
    * which redirects to SU's login.
    */
   async authorize(client, params, res) {
-    console.error(`[OAuth] authorize — showing connection form`);
+    log(`[OAuth] authorize — showing connection form`);
     const sessionId = generateToken();
     await this.store.saveOAuthSession(sessionId, {
       clientId: client.client_id,
@@ -119,7 +120,7 @@ class SUMcpOAuthProvider {
    * @param {string} uid - Search Client UID (used in search/analytics API calls)
    */
   async handleAuthorizeStart(sessionId, instanceUrl, suClientId, suClientSecret, uid) {
-    console.error(`[OAuth] authorize/start — redirecting to SU login: ${instanceUrl}`);
+    log(`[OAuth] authorize/start — redirecting to SU login: ${instanceUrl}`);
     return this._handleAuthorizeStartInternal(sessionId, instanceUrl, suClientId, suClientSecret, uid);
   }
 
@@ -180,7 +181,7 @@ class SUMcpOAuthProvider {
       isEcosystem,
     });
 
-    console.error(`[OAuth] su-callback (tool) — login completed for: ${session.instanceUrl} user: ${maskEmail(suTokens._email)}`);
+    log(`[OAuth] su-callback (tool) — login completed for: ${session.instanceUrl} user: ${maskEmail(suTokens._email)}`);
     await this.store.deleteOAuthSession(sessionId);
     return true;
   }
@@ -201,10 +202,10 @@ class SUMcpOAuthProvider {
         session.instanceUrl, suAuthCode, session.suClientId, session.suClientSecret
       );
     } catch (err) {
-      console.error(`[OAuth] su-callback — SU token exchange failed: ${err.message}`);
+      log(`[OAuth] su-callback — SU token exchange failed: ${err.message}`);
       throw err;
     }
-    console.error(`[OAuth] su-callback — login completed for: ${session.instanceUrl} user: ${maskEmail(suTokens._email)}`);
+    log(`[OAuth] su-callback — login completed for: ${session.instanceUrl} user: ${maskEmail(suTokens._email)}`);
 
     const rawAccessToken = suTokens.access_token || suTokens.accessToken;
     const uidType = await this._detectUidType(session.instanceUrl, rawAccessToken, session.uid);
@@ -361,10 +362,10 @@ class SUMcpOAuthProvider {
   async exchangeAuthorizationCode(client, authorizationCode) {
     const codeData = await this.store.getAuthCode(authorizationCode);
     if (!codeData) {
-      console.error(`[OAuth] token exchange failed — invalid or expired auth code`);
+      log(`[OAuth] token exchange failed — invalid or expired auth code`);
       throw new Error("Invalid or expired authorization code");
     }
-    console.error(`[OAuth] token exchange — access token issued for client: ${client.client_id?.slice(0, 8)}...`);
+    log(`[OAuth] token exchange — access token issued for client: ${client.client_id?.slice(0, 8)}...`);
 
     await this.store.deleteAuthCode(authorizationCode);
 
@@ -399,10 +400,10 @@ class SUMcpOAuthProvider {
   async exchangeRefreshToken(client, refreshToken, scopes) {
     const refreshData = await this.store.getRefreshToken(refreshToken);
     if (!refreshData) {
-      console.error(`[OAuth] token refresh failed — invalid or expired refresh token for client: ${client.client_id?.slice(0, 8)}...`);
+      log(`[OAuth] token refresh failed — invalid or expired refresh token for client: ${client.client_id?.slice(0, 8)}...`);
       throw new Error("Invalid or expired refresh token");
     }
-    console.error(`[OAuth] token refresh — new access token issued for client: ${client.client_id?.slice(0, 8)}...`);
+    log(`[OAuth] token refresh — new access token issued for client: ${client.client_id?.slice(0, 8)}...`);
 
     const accessToken = generateToken();
     const newRefreshToken = generateToken();

--- a/src/auth/oauth-provider.js
+++ b/src/auth/oauth-provider.js
@@ -280,8 +280,7 @@ class SUMcpOAuthProvider {
             try {
               const parsed = JSON.parse(data);
               if (parsed.access_token || parsed.accessToken) {
-                console.error(`[OAuth] SU token response keys: ${Object.keys(parsed).join(', ')}; user field: ${JSON.stringify(parsed.user)}`);
-                parsed._email = parsed.user?.username ?? null;
+                parsed._email = parsed.user?.user_email ?? parsed.user?.username ?? null;
                 resolve(parsed);
               } else {
                 reject(new Error(`SU token exchange failed: ${data}`));

--- a/src/auth/store.js
+++ b/src/auth/store.js
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { log } from "../logger.js";
 
 const ENCRYPTION_ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 16;
@@ -159,7 +160,7 @@ class RedisStore {
       });
       this.redis.on("error", (err) => {
         this.connected = false;
-        console.error("[Redis] Connection error:", err.message);
+        log("[Redis] Connection error:", err.message);
       });
       this.redis.on("connect", () => { this.connected = true; });
       this.redis.on("close", () => { this.connected = false; });
@@ -168,7 +169,7 @@ class RedisStore {
       return true;
     } catch (err) {
       this.connected = false;
-      console.error("[Redis] Failed to connect:", err.message);
+      log("[Redis] Failed to connect:", err.message);
       return false;
     }
   }
@@ -209,7 +210,7 @@ class RedisStore {
     try {
       return decryptPayload(d, true);
     } catch (err) {
-      console.error(`[Redis] getAccessToken — decrypt error: ${err.message}`);
+      log(`[Redis] getAccessToken — decrypt error: ${err.message}`);
       return null;
     }
   }
@@ -233,10 +234,10 @@ class RedisStore {
 function createStore(redisUrl) {
   const url = redisUrl || process.env.REDIS_URL;
   if (url) {
-    console.error("[Store] Using Redis store");
+    log("[Store] Using Redis store");
     return new RedisStore(url);
   }
-  console.error("[Store] Using in-memory store (tokens lost on restart)");
+  log("[Store] Using in-memory store (tokens lost on restart)");
   return new MemoryStore();
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -241,6 +241,10 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: "Too many requests, please try again later" },
+    handler: (req, res, next, options) => {
+      console.error(`[RateLimit] auth — ${req.method} ${req.path} from ${req.ip}`);
+      res.status(options.statusCode).json(options.message);
+    },
   });
 
   // Guard: reject OAuth requests if store is unavailable
@@ -492,6 +496,7 @@ function setupNonOAuthMcpRoutes(app, creds, mcpRateLimit) {
     try {
       const requestCreds = getCredsFromHeaders(req.headers || {});
       if (!requestCreds) {
+        console.error(`[MCP] mcp-api unauthorized — missing headers from ${req.headers["x-forwarded-for"] ?? req.ip ?? "unknown"}`);
         return res.status(401).json({ error: "unauthorized", error_description: "Missing or incomplete searchunify-* headers" });
       }
       await serveStatelessMcpRequest(req, res, requestCreds);
@@ -607,6 +612,10 @@ async function runHttp(creds, port) {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: "Too many requests, please try again later" },
+    handler: (req, res, next, options) => {
+      console.error(`[RateLimit] mcp — ${req.method} ${req.path} from ${req.ip}`);
+      res.status(options.statusCode).json(options.message);
+    },
   });
 
   if (oauthEnabled && oauthProvider) {

--- a/src/index.js
+++ b/src/index.js
@@ -584,8 +584,14 @@ async function runHttp(creds, port) {
 
   const healthResponse = () => ({ data: [{ serviceName: "su-mcp", currentStatus: "Operational", version: pkg.version }] });
 
-  app.get("/health", (req, res) => res.json(healthResponse()));
-  app.get("/pollApi", (req, res) => res.json(healthResponse()));
+  app.get("/health", (req, res) => {
+    console.error(`[HTTP] ${new Date().toISOString()} GET /health`);
+    res.json(healthResponse());
+  });
+  app.get("/pollApi", (req, res) => {
+    console.error(`[HTTP] ${new Date().toISOString()} GET /pollApi`);
+    res.json(healthResponse());
+  });
 
   // OpenAI domain verification — serves the challenge token at the well-known URL
   app.get("/.well-known/openai-apps-challenge", (req, res) => {

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,19 @@ h1{color:#16a34a;font-size:20px;margin-bottom:12px}p{color:#555;font-size:14px;l
 <p>You have been connected to SearchUnify.<br>Return to Claude and continue your conversation.</p></div>${redirect}</body></html>`;
 }
 
+function loginErrorHTML(message, nonce) {
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Configuration Error</title>
+<style nonce="${nonce}">body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;background:#f5f7fa;margin:0}
+.card{background:#fff;border-radius:12px;box-shadow:0 2px 12px rgba(0,0,0,0.08);padding:40px;max-width:480px;text-align:center}
+h1{color:#dc2626;font-size:20px;margin-bottom:12px}p{color:#555;font-size:14px;line-height:1.6}
+.hint{margin-top:16px;padding:12px;background:#fef2f2;border-radius:8px;font-size:13px;color:#b91c1c}</style></head>
+<body><div class="card"><h1>&#10060; Invalid Configuration</h1>
+<p>${message.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>
+<div class="hint">To find the correct UID, go to your SearchUnify admin panel &rarr; <strong>Search Clients</strong> (for a search client UID) or <strong>Ecosystems</strong> (for an ecosystem UID), then reconnect.</div>
+</div></body></html>`;
+}
+
 async function validateAuthorizeBody(body, store) {
   const { session, instance, uid, su_client_id, su_client_secret } = body;
   if (!session || !instance || !uid || !su_client_id || !su_client_secret) {
@@ -284,7 +297,11 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
       res.redirect(302, redirectUrl);
     } catch (err) {
       console.error("[OAuth] SU callback error:", err.message);
-      // Don't leak internal error details to the user
+      if (err.code === 'INVALID_UID') {
+        const nonce = generateNonce();
+        res.set("Content-Security-Policy", `default-src 'none'; style-src 'nonce-${nonce}'; frame-ancestors 'none'`);
+        return res.status(400).type("html").send(loginErrorHTML(err.message, nonce));
+      }
       res.status(400).send("Authorization failed. Please try again.");
     }
   });

--- a/src/index.js
+++ b/src/index.js
@@ -474,6 +474,33 @@ function setupNonOAuthMcpRoutes(app, creds, mcpRateLimit) {
     }
   });
 
+  // /mcp-api — header-based auth, always available regardless of OAuth mode.
+  // Intended for shared/service-account setups (e.g. Microsoft Copilot / Power Platform connectors)
+  // where an admin configures credentials once and all users share them via request headers.
+  // Use apiKey auth: searchunify-auth-type: apiKey + searchunify-api-key: <key>
+  app.options("/mcp-api", (req, res) => {
+    res.set("Access-Control-Allow-Origin", "*");
+    res.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE");
+    res.set("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id, Accept, searchunify-instance, searchunify-uid, searchunify-auth-type, searchunify-api-key, searchunify-oauth-client-id, searchunify-oauth-client-secret, searchunify-timeout, searchunify-ecosystem-id");
+    res.set("Access-Control-Expose-Headers", "mcp-session-id");
+    res.status(204).end();
+  });
+
+  app.all("/mcp-api", mcpRateLimit, express.json(), async (req, res) => {
+    const ts = new Date().toISOString();
+    console.error(`[MCP HTTP] ${ts} ${req.method} /mcp-api (api-key)`);
+    try {
+      const requestCreds = getCredsFromHeaders(req.headers || {});
+      if (!requestCreds) {
+        return res.status(401).json({ error: "unauthorized", error_description: "Missing or incomplete searchunify-* headers" });
+      }
+      await serveStatelessMcpRequest(req, res, requestCreds);
+    } catch (err) {
+      console.error(`[MCP] mcp-api handler error: ${err.message}`);
+      if (!res.headersSent) res.status(500).json({ error: "server_error", error_description: "An internal error occurred." });
+    }
+  });
+
   // Legacy root endpoint for backward compatibility
   app.all("/", mcpRateLimit, express.json(), async (req, res) => {
     const ts = new Date().toISOString();

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
+import { log } from "./logger.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import express from "express";
@@ -53,7 +54,7 @@ async function runStdio(creds) {
   await initializeTools({ server, creds });
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("SearchUnify MCP Server running on stdio");
+  log("SearchUnify MCP Server running on stdio");
 }
 
 
@@ -137,7 +138,7 @@ async function serveStatelessMcpRequest(req, res, requestCreds) {
     const instance = requestCreds?.config?.instance ?? "unauthenticated";
     const clientId = req.auth?.clientId ? `client:${req.auth.clientId.slice(0, 8)}` : null;
     const parts = [instance, clientId].filter(Boolean).join(" ");
-    console.error(`[Tool] ${req.body.params?.name ?? "unknown"} — ${req.method} ${req.path} from ${ip} (${parts})`);
+    log(`[Tool] ${req.body.params?.name ?? "unknown"} — ${req.method} ${req.path} from ${ip} (${parts})`);
   }
   const reqServer = createMcpServer();
   const getCreds = () => requestCreds;
@@ -206,7 +207,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
       try {
         const existing = await oauthProvider.clientsStore.getClient(client_id);
         if (!existing) {
-          console.error(`[OAuth] /authorize — unknown client ${client_id.slice(0, 8)}..., auto-registering with redirect_uri ${redirect_uri}`);
+          log(`[OAuth] /authorize — unknown client ${client_id.slice(0, 8)}..., auto-registering with redirect_uri ${redirect_uri}`);
           await oauthProvider.clientsStore.registerClient({
             client_id,
             redirect_uris: [redirect_uri],
@@ -217,7 +218,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
           });
         }
       } catch (err) {
-        console.error(`[OAuth] /authorize auto-registration error: ${err.message}`);
+        log(`[OAuth] /authorize auto-registration error: ${err.message}`);
       }
     }
     next();
@@ -242,7 +243,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
     legacyHeaders: false,
     message: { error: "Too many requests, please try again later" },
     handler: (req, res, next, options) => {
-      console.error(`[RateLimit] auth — ${req.method} ${req.path} from ${req.ip}`);
+      log(`[RateLimit] auth — ${req.method} ${req.path} from ${req.ip}`);
       res.status(options.statusCode).json(options.message);
     },
   });
@@ -250,7 +251,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
   // Guard: reject OAuth requests if store is unavailable
   const requireStore = (req, res, next) => {
     if (!oauthProvider.isReady()) {
-      console.error("[OAuth] Store unavailable — rejecting request");
+      log("[OAuth] Store unavailable — rejecting request");
       return res.status(503).json({ error: "Service temporarily unavailable. Please try again later." });
     }
     next();
@@ -269,7 +270,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
       );
       return res.json({ redirectUrl: suAuthorizeUrl });
     } catch (err) {
-      console.error("[OAuth] Authorize start error:", err.message);
+      log("[OAuth] Authorize start error:", err.message);
       return res.status(500).json({ error: "Authorization failed. Please try again." });
     }
   });
@@ -279,7 +280,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
   app.all(`${basePath}/su-callback`, requireStore, authRateLimit, express.urlencoded({ extended: false, limit: "10kb" }), async (req, res) => {
     try {
       const { code, state } = { ...req.query, ...req.body };
-      console.error(`[OAuth] /su-callback received — code: ${code?.slice(0, 8)}... state: ${state?.slice(0, 8)}... (len: ${state?.length})`);
+      log(`[OAuth] /su-callback received — code: ${code?.slice(0, 8)}... state: ${state?.slice(0, 8)}... (len: ${state?.length})`);
       if (!code || !state) {
         return res.status(400).send("Missing code or state from SearchUnify");
       }
@@ -300,7 +301,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
       const redirectUrl = await oauthProvider.handleSuCallback(code, state);
       res.redirect(302, redirectUrl);
     } catch (err) {
-      console.error("[OAuth] SU callback error:", err.message);
+      log("[OAuth] SU callback error:", err.message);
       if (err.code === 'INVALID_UID') {
         const nonce = generateNonce();
         res.set("Content-Security-Policy", `default-src 'none'; style-src 'nonce-${nonce}'; frame-ancestors 'none'`);
@@ -326,7 +327,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
 
   app.all(`${basePath}/mcp`, express.json(), bearerAuth, async (req, res) => {
     const ts = new Date().toISOString();
-    console.error(`[MCP HTTP] ${ts} ${req.method} ${basePath}/mcp (OAuth)`);
+    log(`[MCP HTTP] ${ts} ${req.method} ${basePath}/mcp (OAuth)`);
     try {
       const token = req.headers.authorization?.split(" ")[1];
       const suTokens = token ? await oauthProvider.getSuTokensForMcpToken(token) : null;
@@ -337,7 +338,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
       const requestCreds = buildCredsFromSuToken(suTokens);
       await serveStatelessMcpRequest(req, res, requestCreds);
     } catch (err) {
-      console.error(`[MCP] HANDLER ERROR: ${err.message}`);
+      log(`[MCP] HANDLER ERROR: ${err.message}`);
       if (!res.headersSent) res.status(500).json({ error: "server_error", error_description: err.message });
     }
   });
@@ -390,7 +391,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
       );
       return res.json({ redirectUrl: suAuthorizeUrl });
     } catch (err) {
-      console.error("[mcp-connect] Authorize start error:", err.message);
+      log("[mcp-connect] Authorize start error:", err.message);
       return res.status(500).json({ error: "Authorization failed. Please try again." });
     }
   });
@@ -398,10 +399,10 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
   // MCP endpoint — stateful, no OAuth middleware
   app.all("/mcp-connect", mcpRateLimit, express.json(), async (req, res) => {
     const ts = new Date().toISOString();
-    console.error(`[MCP HTTP] ${ts} ${req.method} /mcp-connect (tool-auth)`);
+    log(`[MCP HTTP] ${ts} ${req.method} /mcp-connect (tool-auth)`);
     if (req.body?.method === "tools/call") {
       const ip = req.headers["x-forwarded-for"] ?? req.ip ?? "unknown";
-      console.error(`[Tool] ${req.body.params?.name ?? "unknown"} — ${req.method} ${req.path} from ${ip}`);
+      log(`[Tool] ${req.body.params?.name ?? "unknown"} — ${req.method} ${req.path} from ${ip}`);
     }
 
     try {
@@ -445,7 +446,7 @@ function setupOAuthRoutes(app, port, oauthProvider, mcpRateLimit) {
       await reqServer.connect(reqTransport);
       await reqTransport.handleRequest(req, res, req.body);
     } catch (err) {
-      console.error(`[mcp-connect] handler error: ${err.message}`);
+      log(`[mcp-connect] handler error: ${err.message}`);
       if (!res.headersSent) res.status(500).json({ error: "server_error", error_description: err.message });
     }
   });
@@ -468,12 +469,12 @@ function setupNonOAuthMcpRoutes(app, creds, mcpRateLimit) {
   // Non-OAuth MCP endpoint — header-based auth (backward compatible)
   app.all("/mcp", mcpRateLimit, express.json(), async (req, res) => {
     const ts = new Date().toISOString();
-    console.error(`[MCP HTTP] ${ts} ${req.method} /mcp (headers)`);
+    log(`[MCP HTTP] ${ts} ${req.method} /mcp (headers)`);
     try {
       const requestCreds = getCredsFromHeaders(req.headers || {}) || creds;
       await serveStatelessMcpRequest(req, res, requestCreds);
     } catch (err) {
-      console.error(`[MCP] headers handler error: ${err.message}`);
+      log(`[MCP] headers handler error: ${err.message}`);
       if (!res.headersSent) res.status(500).json({ error: "server_error", error_description: err.message });
     }
   });
@@ -492,16 +493,16 @@ function setupNonOAuthMcpRoutes(app, creds, mcpRateLimit) {
 
   app.all("/mcp-api", mcpRateLimit, express.json(), async (req, res) => {
     const ts = new Date().toISOString();
-    console.error(`[MCP HTTP] ${ts} ${req.method} /mcp-api (api-key)`);
+    log(`[MCP HTTP] ${ts} ${req.method} /mcp-api (api-key)`);
     try {
       const requestCreds = getCredsFromHeaders(req.headers || {});
       if (!requestCreds) {
-        console.error(`[MCP] mcp-api unauthorized — missing headers from ${req.headers["x-forwarded-for"] ?? req.ip ?? "unknown"}`);
+        log(`[MCP] mcp-api unauthorized — missing headers from ${req.headers["x-forwarded-for"] ?? req.ip ?? "unknown"}`);
         return res.status(401).json({ error: "unauthorized", error_description: "Missing or incomplete searchunify-* headers" });
       }
       await serveStatelessMcpRequest(req, res, requestCreds);
     } catch (err) {
-      console.error(`[MCP] mcp-api handler error: ${err.message}`);
+      log(`[MCP] mcp-api handler error: ${err.message}`);
       if (!res.headersSent) res.status(500).json({ error: "server_error", error_description: "An internal error occurred." });
     }
   });
@@ -509,12 +510,12 @@ function setupNonOAuthMcpRoutes(app, creds, mcpRateLimit) {
   // Legacy root endpoint for backward compatibility
   app.all("/", mcpRateLimit, express.json(), async (req, res) => {
     const ts = new Date().toISOString();
-    console.error(`[MCP HTTP] ${ts} ${req.method} / (legacy)`);
+    log(`[MCP HTTP] ${ts} ${req.method} / (legacy)`);
     try {
       const requestCreds = getCredsFromHeaders(req.headers || {}) || creds;
       await serveStatelessMcpRequest(req, res, requestCreds);
     } catch (err) {
-      console.error(`[MCP] legacy handler error: ${err.message}`);
+      log(`[MCP] legacy handler error: ${err.message}`);
       if (!res.headersSent) res.status(500).json({ error: "server_error", error_description: err.message });
     }
   });
@@ -525,15 +526,15 @@ function setupNonOAuthMcpRoutes(app, creds, mcpRateLimit) {
  */
 function startServer(app, port, oauthEnabled) {
   app.listen(port, () => {
-    console.error(`SearchUnify MCP Server (HTTP) listening on http://localhost:${port}`);
+    log(`SearchUnify MCP Server (HTTP) listening on http://localhost:${port}`);
     if (oauthEnabled) {
-      console.error(`  OAuth endpoints: /authorize, /token, /register`);
-      console.error(`  OAuth metadata: /.well-known/oauth-authorization-server`);
-      console.error(`  Instance form → /authorize/start → SU login → /su-callback`);
+      log(`  OAuth endpoints: /authorize, /token, /register`);
+      log(`  OAuth metadata: /.well-known/oauth-authorization-server`);
+      log(`  Instance form → /authorize/start → SU login → /su-callback`);
     }
-    console.error(`  MCP endpoint: /mcp`);
+    log(`  MCP endpoint: /mcp`);
     if (oauthEnabled) {
-      console.error(`  Tool-auth endpoint: /mcp-connect (no OAuth — login tool returns form link)`);
+      log(`  Tool-auth endpoint: /mcp-connect (no OAuth — login tool returns form link)`);
     }
   });
 }
@@ -546,15 +547,15 @@ async function runHttp(creds, port) {
     oauthProvider = new SUMcpOAuthProvider(process.env.REDIS_URL);
     const storeConnected = await oauthProvider.connect();
     if (storeConnected) {
-      console.error("[OAuth] OAuth enabled — proxy flow via SU login");
+      log("[OAuth] OAuth enabled — proxy flow via SU login");
     } else {
-      console.error("[OAuth] WARNING: Store not reachable — OAuth disabled, server will run without OAuth");
+      log("[OAuth] WARNING: Store not reachable — OAuth disabled, server will run without OAuth");
       try { await oauthProvider.store.disconnect(); } catch {}
       oauthEnabled = false;
       oauthProvider = null;
     }
   } else {
-    console.error("[OAuth] OAuth disabled — set OAUTH_ENCRYPTION_KEY to enable (REDIS_URL optional)");
+    log("[OAuth] OAuth disabled — set OAUTH_ENCRYPTION_KEY to enable (REDIS_URL optional)");
   }
 
   const app = express();
@@ -590,11 +591,11 @@ async function runHttp(creds, port) {
   const healthResponse = () => ({ data: [{ serviceName: "su-mcp", currentStatus: "Operational", version: pkg.version }] });
 
   app.get("/health", (req, res) => {
-    console.error(`[HTTP] ${new Date().toISOString()} GET /health`);
+    log(`[HTTP] ${new Date().toISOString()} GET /health`);
     res.json(healthResponse());
   });
   app.get("/pollApi", (req, res) => {
-    console.error(`[HTTP] ${new Date().toISOString()} GET /pollApi`);
+    log(`[HTTP] ${new Date().toISOString()} GET /pollApi`);
     res.json(healthResponse());
   });
 
@@ -613,7 +614,7 @@ async function runHttp(creds, port) {
     legacyHeaders: false,
     message: { error: "Too many requests, please try again later" },
     handler: (req, res, next, options) => {
-      console.error(`[RateLimit] mcp — ${req.method} ${req.path} from ${req.ip}`);
+      log(`[RateLimit] mcp — ${req.method} ${req.path} from ${req.ip}`);
       res.status(options.statusCode).json(options.message);
     },
   });
@@ -647,7 +648,7 @@ async function main() {
       const creds = validateCreds();
       await runStdio(creds);
     } catch (err) {
-      console.error("validateCreds failed in TRANSPORT_BOTH mode, falling back to http only:", err?.message ?? err);
+      log("validateCreds failed in TRANSPORT_BOTH mode, falling back to http only:", err?.message ?? err);
     }
     await runHttp(null, port);
     return;
@@ -655,6 +656,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error("Fatal error in main():", error);
+  log("Fatal error in main():", error);
   process.exit(1);
 });

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,1 @@
+export const log = (...args) => console.error(new Date().toISOString(), ...args);

--- a/src/su-core/leadership-direct-view.js
+++ b/src/su-core/leadership-direct-view.js
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { log } from "../logger.js";
 
 const require = createRequire(import.meta.url);
 const { HttpRequest, requestMethods } = require("su-sdk/src/utils/request-handler.js");
@@ -61,7 +62,7 @@ export async function resolveDirectlyViewSetting(credsForRequest, args) {
     auth
   );
   if (response?.status === false) {
-    console.error(
+    log(
       "leadership-direct-view: caseDeflectionFormulaAndSettings failed:",
       response.message || response
     );

--- a/src/su-core/su-core-analytics.js
+++ b/src/su-core/su-core-analytics.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { formatForClaude } from "./../utils.js";
 import { analyticsToolAnnotations } from "../tool-annotations-meta.js";
+import { log } from "../logger.js";
 import {
   RECIPES,
   executiveOptionsForAnalyticsTool,
@@ -801,7 +802,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
       let analyticsResponse = {};
       switch (reportType) {
         case reportTypes.searchQueryWithNoClicks: {
-          console.error("searchQueryWithNoClicks triggered");
+          log("searchQueryWithNoClicks triggered");
           analyticsResponse = await Analytics.searchQueryWithNoClicks({
             ...searchClientScope(args, credsForRequest),
             startDate, endDate, count, pageNumber, sortByField, sortType,
@@ -809,7 +810,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.searchQueryWithResult: {
-          console.error("searchQueryWithResult triggered");
+          log("searchQueryWithResult triggered");
           analyticsResponse = await Analytics.searchQueryWithResult({
             ...searchClientScope(args, credsForRequest),
             startDate, endDate, count, pageNumber, sortByField, sortType,
@@ -817,7 +818,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.searchQueryWithoutResults: {
-          console.error("searchQueryWithoutResults triggered");
+          log("searchQueryWithoutResults triggered");
           analyticsResponse = await Analytics.searchQueryWithoutResults({
             ...searchClientScope(args, credsForRequest),
             startDate, endDate, count, pageNumber, sortByField, sortType,
@@ -825,7 +826,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.getAllSearchQuery: {
-          console.error("getAllSearchQuery triggered");
+          log("getAllSearchQuery triggered");
           analyticsResponse = await Analytics.getAllSearchQuery({
             ...searchClientScope(args, credsForRequest),
             startDate, endDate, count, pageNumber, sortByField, sortType,
@@ -833,12 +834,12 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.getAllSearchConversion: {
-          console.error("getAllSearchConversion triggered");
+          log("getAllSearchConversion triggered");
           analyticsResponse = await Analytics.getAllSearchConversion({ ...searchClientScope(args, credsForRequest), startDate, endDate, count });
           break;
         }
         case reportTypes.averageClickPosition: {
-          console.error("averageClickPosition triggered");
+          log("averageClickPosition triggered");
           analyticsResponse = await Analytics.getAverageClickPosition({
             ...searchClientScope(args, credsForRequest),
             startDate, endDate, internalUser: "all",
@@ -846,7 +847,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.sessionDetails: {
-          console.error("sessionDetails triggered");
+          log("sessionDetails triggered");
           const sessionParams = {
             searchClientId: resolvedSearchClientUid(args, credsForRequest),
             startDate,
@@ -865,7 +866,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.sessionList: {
-          console.error("sessionList triggered");
+          log("sessionList triggered");
           const sessionParams = {
             searchClientId: resolvedSearchClientUid(args, credsForRequest),
             startDate,
@@ -884,7 +885,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.tileDataContent: {
-          console.error("tileDataContent triggered");
+          log("tileDataContent triggered");
           const tileParams = {
             startDate,
             endDate,
@@ -903,7 +904,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         // case reportTypes.contentSplitTileDataContent: {
-        //   console.error("contentSplitTileDataContent triggered");
+        //   log("contentSplitTileDataContent triggered");
         //   if (!args.ecoSystemId) {
         //     return jsonTextResult({
         //       error:
@@ -918,14 +919,14 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         //   break;
         // }
         case reportTypes.contentUnsuccessfulSummaryChart: {
-          console.error("contentUnsuccessfulSummaryChart triggered");
+          log("contentUnsuccessfulSummaryChart triggered");
           analyticsResponse = await Analytics.postContentUnsuccessfulSummaryChart(
             conversionPostBase(args, credsForRequest)
           );
           break;
         }
         case reportTypes.contentSearchesWithNoClicks: {
-          console.error("contentSearchesWithNoClicks triggered");
+          log("contentSearchesWithNoClicks triggered");
           analyticsResponse = await Analytics.postOverviewSearchesWithNoClicks({
             ...conversionPostBase(args, credsForRequest),
             searchQuery: contentGapSearchQuery ?? "",
@@ -938,7 +939,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.contentSuccessiveNoClicks: {
-          console.error("contentSuccessiveNoClicks triggered");
+          log("contentSuccessiveNoClicks triggered");
           const txt = contentGapText?.trim();
           if (!txt) {
             return jsonTextResult({
@@ -953,7 +954,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.contentSearchesWithNoResult: {
-          console.error("contentSearchesWithNoResult triggered");
+          log("contentSearchesWithNoResult triggered");
           const actionStatusFilters = resolvedContentGapActionStatusFilters(contentGapActionStatusFilters);
           analyticsResponse = await Analytics.postOverviewSearchesWithNoResult({
             ...conversionPostBase(args, credsForRequest),
@@ -968,7 +969,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.contentSuccessiveNoResults: {
-          console.error("contentSuccessiveNoResults triggered");
+          log("contentSuccessiveNoResults triggered");
           const txt = contentGapText?.trim();
           if (!txt) {
             return jsonTextResult({
@@ -983,14 +984,14 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.contentUnsuccessfulSearchSessionChart: {
-          console.error("contentUnsuccessfulSearchSessionChart triggered");
+          log("contentUnsuccessfulSearchSessionChart triggered");
           analyticsResponse = await Analytics.postContentUnsuccessfulSearchSessionChart(
             conversionPostBase(args, credsForRequest)
           );
           break;
         }
         case reportTypes.contentArticleUsageByAgents: {
-          console.error("contentArticleUsageByAgents triggered");
+          log("contentArticleUsageByAgents triggered");
           analyticsResponse = await Analytics.postContentArticleUsageByAgents({
             ...conversionPostBase(args, credsForRequest),
             orderBy: String(contentGapOrderBy ?? "DESC").toUpperCase(),
@@ -999,7 +1000,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.contentSuccessiveArticlesUsage: {
-          console.error("contentSuccessiveArticlesUsage triggered");
+          log("contentSuccessiveArticlesUsage triggered");
           const txt = contentGapText?.trim();
           if (!txt) {
             return jsonTextResult({
@@ -1017,7 +1018,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewSessionCount: {
-          console.error("overviewSessionCount triggered");
+          log("overviewSessionCount triggered");
           const tileParams = { startDate, endDate };
           if (args.ecoSystemId) {
             tileParams.ecoSystemId = args.ecoSystemId;
@@ -1042,7 +1043,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewTileDataCount: {
-          console.error("overviewTileDataCount triggered");
+          log("overviewTileDataCount triggered");
           const tileScope = args.ecoSystemId
             ? { ecoSystemId: args.ecoSystemId }
             : credsForRequest.config.ecoSystemId
@@ -1052,7 +1053,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewTopSearches: {
-          console.error("overviewTopSearches triggered");
+          log("overviewTopSearches triggered");
           analyticsResponse = await Analytics.postOverviewTopSearches({
             ...conversionPostBase(args, credsForRequest),
             searchQuery: contentGapSearchQuery ?? "",
@@ -1065,7 +1066,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewSearchSessions: {
-          console.error("overviewSearchSessions triggered");
+          log("overviewSearchSessions triggered");
           analyticsResponse = await Analytics.postOverviewSearchSessions({
             ...conversionPostBase(args, credsForRequest),
             searchQuery: contentGapSearchQuery ?? "",
@@ -1078,7 +1079,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewSearchClickPosition: {
-          console.error("overviewSearchClickPosition triggered");
+          log("overviewSearchClickPosition triggered");
           analyticsResponse = await Analytics.getOverviewSearchClickPosition({
             ...scopeParamsForOverview(args, credsForRequest),
             searchQuery: searchQuery ?? "",
@@ -1089,7 +1090,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewCreatedCases: {
-          console.error("overviewCreatedCases triggered");
+          log("overviewCreatedCases triggered");
           analyticsResponse = await Analytics.getOverviewCreatedCases({
             ...scopeParamsForOverview(args, credsForRequest),
             caseUid: casesCaseUid ?? "",
@@ -1102,21 +1103,21 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewFeaturedSnippet: {
-          console.error("overviewFeaturedSnippet triggered");
+          log("overviewFeaturedSnippet triggered");
           analyticsResponse = await Analytics.getOverviewFeaturedSnippet(
             scopeParamsForSimilarValidationOverview(args, credsForRequest)
           );
           break;
         }
         case reportTypes.overviewKnowledgeTitle: {
-          console.error("overviewKnowledgeTitle triggered");
+          log("overviewKnowledgeTitle triggered");
           analyticsResponse = await Analytics.getOverviewKnowledgeTitle(
             scopeParamsForSimilarValidationOverview(args, credsForRequest)
           );
           break;
         }
         case reportTypes.overviewPageRating: {
-          console.error("overviewPageRating triggered");
+          log("overviewPageRating triggered");
           analyticsResponse = await Analytics.getOverviewPageRating({
             ...scopeParamsForOverview(args, credsForRequest),
             pageNumber: pageNumber ?? 1,
@@ -1124,7 +1125,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewSearchFeedback: {
-          console.error("overviewSearchFeedback triggered");
+          log("overviewSearchFeedback triggered");
           analyticsResponse = await Analytics.getOverviewSearchFeedback({
             ...scopeParamsForOverview(args, credsForRequest),
             pageNumber: pageNumber ?? 1,
@@ -1132,7 +1133,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.overviewAdvertisements: {
-          console.error("overviewAdvertisements triggered");
+          log("overviewAdvertisements triggered");
           analyticsResponse = await Analytics.getOverviewAdvertisements({
             ...scopeParamsForOverview(args, credsForRequest),
             pageNumber: pageNumber ?? 1,
@@ -1142,7 +1143,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.llmResponseFeedback: {
-          console.error("llmResponseFeedback triggered");
+          log("llmResponseFeedback triggered");
           const llmUid = resolvedSearchClientUid(args, credsForRequest);
           if (!llmUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.getLlmResponseFeedback(
@@ -1151,7 +1152,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.sessionTrackingFormattedResult: {
-          console.error("sessionTrackingFormattedResult triggered");
+          log("sessionTrackingFormattedResult triggered");
           const stf = {
             startDate,
             endDate,
@@ -1170,12 +1171,12 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionClicksCountContentSource: {
-          console.error("conversionClicksCountContentSource triggered");
+          log("conversionClicksCountContentSource triggered");
           analyticsResponse = await Analytics.postClicksCountContentSource(conversionPostBase(args, credsForRequest));
           break;
         }
         case reportTypes.conversionSearchSummary: {
-          console.error("conversionSearchSummary triggered");
+          log("conversionSearchSummary triggered");
           const sBody = {
             ...conversionPostBase(args, credsForRequest),
             limit: count,
@@ -1185,7 +1186,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionTopClickedDocs: {
-          console.error("conversionTopClickedDocs triggered");
+          log("conversionTopClickedDocs triggered");
           const tBody = { ...conversionPostBase(args, credsForRequest) };
           if (conversionDetailLimit != null) tBody.limit = conversionDetailLimit;
           if (conversionDetailOffset != null) tBody.offset = conversionDetailOffset;
@@ -1207,7 +1208,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionTopSearchesWithClicks: {
-          console.error("conversionTopSearchesWithClicks triggered");
+          log("conversionTopSearchesWithClicks triggered");
           const tsBody = { ...conversionPostBase(args, credsForRequest) };
           if (conversionDetailLimit != null) tsBody.limit = conversionDetailLimit;
           if (conversionDetailOffset != null) tsBody.offset = conversionDetailOffset;
@@ -1229,7 +1230,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionCurrentRelevanceIndex: {
-          console.error("conversionCurrentRelevanceIndex triggered");
+          log("conversionCurrentRelevanceIndex triggered");
           const criUid = resolvedSearchClientUid(args, credsForRequest);
           if (!criUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.postCurrentRelevanceIndex({
@@ -1239,7 +1240,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionRelevanceIndex: {
-          console.error("conversionRelevanceIndex triggered");
+          log("conversionRelevanceIndex triggered");
           const riUid = resolvedSearchClientUid(args, credsForRequest);
           if (!riUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.postRelevanceIndex({
@@ -1251,12 +1252,12 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionCaseDeflectionStage1: {
-          console.error("conversionCaseDeflectionStage1 triggered");
+          log("conversionCaseDeflectionStage1 triggered");
           analyticsResponse = await Analytics.postCaseDeflectionStage1(conversionPostBase(args, credsForRequest));
           break;
         }
         case reportTypes.conversionSessionTrackingDetails: {
-          console.error("conversionSessionTrackingDetails triggered");
+          log("conversionSessionTrackingDetails triggered");
           const sdBody = {
             ...conversionPostBase(args, credsForRequest),
             keyword: conversionDetailKeyword ?? "",
@@ -1274,7 +1275,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionDiscussions: {
-          console.error("conversionDiscussions triggered");
+          log("conversionDiscussions triggered");
           const dBody = { ...conversionPostBase(args, credsForRequest) };
           if (conversionDetailLimit != null) dBody.limit = conversionDetailLimit;
           if (conversionDetailOffset != null) dBody.offset = conversionDetailOffset;
@@ -1282,7 +1283,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionAttachedArticles: {
-          console.error("conversionAttachedArticles triggered");
+          log("conversionAttachedArticles triggered");
           const attachedUid = resolvedSearchClientUid(args, credsForRequest);
           if (!attachedUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.getAttachedArticles({
@@ -1299,7 +1300,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionArticlesCreatedCases: {
-          console.error("conversionArticlesCreatedCases triggered");
+          log("conversionArticlesCreatedCases triggered");
           const createdUid = resolvedSearchClientUid(args, credsForRequest);
           if (!createdUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.getCaseCreatedArticles({
@@ -1317,7 +1318,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionArticlesDeflectedCase: {
-          console.error("conversionArticlesDeflectedCase triggered");
+          log("conversionArticlesDeflectedCase triggered");
           const deflectedUid = resolvedSearchClientUid(args, credsForRequest);
           if (!deflectedUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.getCaseDeflectedArticles({
@@ -1394,7 +1395,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         case reportTypes.conversionLinkSharing: {
-          console.error("conversionLinkSharing triggered");
+          log("conversionLinkSharing triggered");
           const lsBody = {
             ...conversionPostBase(args, credsForRequest),
             limit: conversionDetailLimit ?? 10,
@@ -1439,11 +1440,11 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           break;
         }
         default:
-          console.error("invalid reportType ", reportType);
+          log("invalid reportType ", reportType);
       }
 
       if (analyticsResponse?.status === false) {
-        console.error(`[Analytics] API error — reportType: ${reportType}, message: ${analyticsResponse.message}`);
+        log(`[Analytics] API error — reportType: ${reportType}, message: ${analyticsResponse.message}`);
         return jsonTextResult({
           error: analyticsResponse.message || "analytics_request_failed",
           reportType,
@@ -1451,7 +1452,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         });
       }
       if (analyticsResponse?.data === undefined || analyticsResponse?.data === null) {
-        console.error(`[Analytics] empty response — reportType: ${reportType}`);
+        log(`[Analytics] empty response — reportType: ${reportType}`);
         return {
           content: [
             {

--- a/src/su-core/su-core-analytics.js
+++ b/src/su-core/su-core-analytics.js
@@ -1443,6 +1443,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
       }
 
       if (analyticsResponse?.status === false) {
+        console.error(`[Analytics] API error — reportType: ${reportType}, message: ${analyticsResponse.message}`);
         return jsonTextResult({
           error: analyticsResponse.message || "analytics_request_failed",
           reportType,
@@ -1450,6 +1451,7 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         });
       }
       if (analyticsResponse?.data === undefined || analyticsResponse?.data === null) {
+        console.error(`[Analytics] empty response — reportType: ${reportType}`);
         return {
           content: [
             {

--- a/src/su-core/su-core-analytics.js
+++ b/src/su-core/su-core-analytics.js
@@ -244,6 +244,12 @@ function resolvedSearchClientUid(args, credsForRequest) {
   return credsForRequest.config.uid;
 }
 
+function searchClientScope(args, credsForRequest) {
+  if (args.ecoSystemId) return { ecoSystemId: args.ecoSystemId };
+  if (credsForRequest.config.ecoSystemId) return { ecoSystemId: credsForRequest.config.ecoSystemId };
+  return { searchClientId: resolvedSearchClientUid(args, credsForRequest) };
+}
+
 /** Core POST /api/v2/conversion/* body: from/to, internalUser, uid or ecoId. MCP does not add `tenantId`; admin/BFF adds it when proxying to analytics. */
 function conversionPostBase(args, credsForRequest) {
   const internalUser = args.internalUser ?? "all";
@@ -797,67 +803,45 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         case reportTypes.searchQueryWithNoClicks: {
           console.error("searchQueryWithNoClicks triggered");
           analyticsResponse = await Analytics.searchQueryWithNoClicks({
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
-            startDate,
-            endDate,
-            count,
-            pageNumber,
-            sortByField,
-            sortType,
+            ...searchClientScope(args, credsForRequest),
+            startDate, endDate, count, pageNumber, sortByField, sortType,
           });
           break;
         }
         case reportTypes.searchQueryWithResult: {
           console.error("searchQueryWithResult triggered");
           analyticsResponse = await Analytics.searchQueryWithResult({
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
-            startDate,
-            endDate,
-            count,
-            pageNumber,
-            sortByField,
-            sortType,
+            ...searchClientScope(args, credsForRequest),
+            startDate, endDate, count, pageNumber, sortByField, sortType,
           });
           break;
         }
         case reportTypes.searchQueryWithoutResults: {
           console.error("searchQueryWithoutResults triggered");
           analyticsResponse = await Analytics.searchQueryWithoutResults({
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
-            startDate,
-            endDate,
-            count,
-            pageNumber,
-            sortByField,
-            sortType,
+            ...searchClientScope(args, credsForRequest),
+            startDate, endDate, count, pageNumber, sortByField, sortType,
           });
           break;
         }
         case reportTypes.getAllSearchQuery: {
           console.error("getAllSearchQuery triggered");
           analyticsResponse = await Analytics.getAllSearchQuery({
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
-            startDate,
-            endDate,
-            count,
-            pageNumber,
-            sortByField,
-            sortType,
+            ...searchClientScope(args, credsForRequest),
+            startDate, endDate, count, pageNumber, sortByField, sortType,
           });
           break;
         }
         case reportTypes.getAllSearchConversion: {
           console.error("getAllSearchConversion triggered");
-          analyticsResponse = await Analytics.getAllSearchConversion({ searchClientId: resolvedSearchClientUid(args, credsForRequest), startDate, endDate, count });
+          analyticsResponse = await Analytics.getAllSearchConversion({ ...searchClientScope(args, credsForRequest), startDate, endDate, count });
           break;
         }
         case reportTypes.averageClickPosition: {
           console.error("averageClickPosition triggered");
           analyticsResponse = await Analytics.getAverageClickPosition({
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
-            startDate,
-            endDate,
-            internalUser: "all",
+            ...searchClientScope(args, credsForRequest),
+            startDate, endDate, internalUser: "all",
           });
           break;
         }
@@ -1059,12 +1043,12 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         }
         case reportTypes.overviewTileDataCount: {
           console.error("overviewTileDataCount triggered");
-          const tileParams = {
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
-            startDate,
-            endDate,
-          };
-          analyticsResponse = await Analytics.getTileDataMetrics2(tileParams);
+          const tileScope = args.ecoSystemId
+            ? { ecoSystemId: args.ecoSystemId }
+            : credsForRequest.config.ecoSystemId
+              ? { ecoSystemId: credsForRequest.config.ecoSystemId }
+              : { searchClientId: resolvedSearchClientUid(args, credsForRequest) };
+          analyticsResponse = await Analytics.getTileDataMetrics2({ ...tileScope, startDate, endDate });
           break;
         }
         case reportTypes.overviewTopSearches: {
@@ -1299,10 +1283,11 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         }
         case reportTypes.conversionAttachedArticles: {
           console.error("conversionAttachedArticles triggered");
+          const attachedUid = resolvedSearchClientUid(args, credsForRequest);
+          if (!attachedUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.getAttachedArticles({
-            startDate,
-            endDate,
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
+            startDate, endDate,
+            searchClientId: attachedUid,
             ecoSystemId: args.ecoSystemId,
             count: conversionDetailLimit ?? count ?? 100,
             offset: conversionArticleOffset ?? conversionDetailOffset ?? 1,
@@ -1315,10 +1300,11 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         }
         case reportTypes.conversionArticlesCreatedCases: {
           console.error("conversionArticlesCreatedCases triggered");
+          const createdUid = resolvedSearchClientUid(args, credsForRequest);
+          if (!createdUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.getCaseCreatedArticles({
-            startDate,
-            endDate,
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
+            startDate, endDate,
+            searchClientId: createdUid,
             ecoSystemId: args.ecoSystemId,
             searchType: conversionSearchTypeArticle ?? "all",
             count: conversionDetailLimit ?? count ?? 100,
@@ -1332,10 +1318,11 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         }
         case reportTypes.conversionArticlesDeflectedCase: {
           console.error("conversionArticlesDeflectedCase triggered");
+          const deflectedUid = resolvedSearchClientUid(args, credsForRequest);
+          if (!deflectedUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.getCaseDeflectedArticles({
-            startDate,
-            endDate,
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
+            startDate, endDate,
+            searchClientId: deflectedUid,
             ecoSystemId: args.ecoSystemId,
             searchType: conversionSearchTypeArticle ?? "all",
             count: conversionDetailLimit ?? count ?? 100,

--- a/src/su-core/su-core-analytics.js
+++ b/src/su-core/su-core-analytics.js
@@ -255,6 +255,9 @@ function conversionPostBase(args, credsForRequest) {
   if (args.ecoSystemId) {
     body.ecoId = args.ecoSystemId;
     body.uid = null;
+  } else if (credsForRequest.config.ecoSystemId) {
+    body.ecoId = credsForRequest.config.ecoSystemId;
+    body.uid = null;
   } else {
     body.uid = resolvedSearchClientUid(args, credsForRequest);
     body.ecoId = null;
@@ -282,6 +285,9 @@ function leadershipUidEcoBody(args, credsForRequest) {
   const base = { internalUser, ...leadershipLastSixQuartersWindow() };
   if (args.ecoSystemId) {
     return { ...base, ecoId: args.ecoSystemId };
+  }
+  if (credsForRequest.config.ecoSystemId) {
+    return { ...base, ecoId: credsForRequest.config.ecoSystemId };
   }
   return { ...base, uid: resolvedSearchClientUid(args, credsForRequest) };
 }
@@ -374,6 +380,9 @@ function scopeParamsForSimilarValidationOverview(args, credsForRequest) {
   if (ecoSystemId) {
     return { ...base, ecoSystemId };
   }
+  if (credsForRequest.config.ecoSystemId) {
+    return { ...base, ecoSystemId: credsForRequest.config.ecoSystemId };
+  }
   return { ...base, searchClientId: resolvedSearchClientUid(args, credsForRequest) };
 }
 
@@ -389,6 +398,9 @@ function scopeParamsForOverview(args, credsForRequest) {
   };
   if (ecoSystemId) {
     return { ...base, ecoSystemId };
+  }
+  if (credsForRequest.config.ecoSystemId) {
+    return { ...base, ecoSystemId: credsForRequest.config.ecoSystemId };
   }
   return { ...base, searchClientId: resolvedSearchClientUid(args, credsForRequest) };
 }
@@ -1022,11 +1034,14 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         }
         case reportTypes.overviewSessionCount: {
           console.error("overviewSessionCount triggered");
-          const tileParams = {
-            searchClientId: resolvedSearchClientUid(args, credsForRequest),
-            startDate,
-            endDate,
-          };
+          const tileParams = { startDate, endDate };
+          if (args.ecoSystemId) {
+            tileParams.ecoSystemId = args.ecoSystemId;
+          } else if (credsForRequest.config.ecoSystemId) {
+            tileParams.ecoSystemId = credsForRequest.config.ecoSystemId;
+          } else {
+            tileParams.searchClientId = resolvedSearchClientUid(args, credsForRequest);
+          }
           analyticsResponse = await Analytics.getTileDataMetrics1(tileParams);
           {
             const d = analyticsResponse?.data;
@@ -1144,6 +1159,8 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         }
         case reportTypes.llmResponseFeedback: {
           console.error("llmResponseFeedback triggered");
+          const llmUid = resolvedSearchClientUid(args, credsForRequest);
+          if (!llmUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.getLlmResponseFeedback(
             paramsForLlmResponseFeedback(args, credsForRequest)
           );
@@ -1229,16 +1246,20 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
         }
         case reportTypes.conversionCurrentRelevanceIndex: {
           console.error("conversionCurrentRelevanceIndex triggered");
+          const criUid = resolvedSearchClientUid(args, credsForRequest);
+          if (!criUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.postCurrentRelevanceIndex({
-            uid: resolvedSearchClientUid(args, credsForRequest),
+            uid: criUid,
             internalUser: internalUser ?? "all",
           });
           break;
         }
         case reportTypes.conversionRelevanceIndex: {
           console.error("conversionRelevanceIndex triggered");
+          const riUid = resolvedSearchClientUid(args, credsForRequest);
+          if (!riUid) return { content: [{ type: "text", text: "This report requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
           analyticsResponse = await Analytics.postRelevanceIndex({
-            uid: resolvedSearchClientUid(args, credsForRequest),
+            uid: riUid,
             internalUser: internalUser ?? "all",
             from: startDate,
             to: endDate,

--- a/src/su-core/su-core-analytics.js
+++ b/src/su-core/su-core-analytics.js
@@ -1461,7 +1461,6 @@ const initializeAnalyticsTools = async ({ server, creds, getCreds }) => {
           ],
         };
       }
-      console.error("analyticsResponse", analyticsResponse.data);
       return formatForClaude(analyticsResponse.data);
     }
   );

--- a/src/su-core/su-core-business-queries.js
+++ b/src/su-core/su-core-business-queries.js
@@ -877,6 +877,7 @@ export const initializeExecutiveBusinessQueryTools = async ({
         }
         return jsonResult(payload);
       } catch (e) {
+        console.error(`[ExecutiveQuery] error — recipeId: ${recipeId}, message: ${e?.message ?? String(e)}`);
         return jsonResult({
           error: e?.message ?? String(e),
           recipeId,

--- a/src/su-core/su-core-business-queries.js
+++ b/src/su-core/su-core-business-queries.js
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { log } from "../logger.js";
 import {
   computeSearchNoClickRatio,
   normalizeSdkResult,
@@ -823,7 +824,7 @@ export const initializeExecutiveBusinessQueryTools = async ({
     async (args) => {
       const credsForRequest = await Promise.resolve(c());
       const { recipeId, ...input } = args;
-      console.error(`[ExecutiveQuery] recipeId: ${recipeId}`);
+      log(`[ExecutiveQuery] recipeId: ${recipeId}`);
       try {
         let payload;
         switch (recipeId) {
@@ -877,7 +878,7 @@ export const initializeExecutiveBusinessQueryTools = async ({
         }
         return jsonResult(payload);
       } catch (e) {
-        console.error(`[ExecutiveQuery] error — recipeId: ${recipeId}, message: ${e?.message ?? String(e)}`);
+        log(`[ExecutiveQuery] error — recipeId: ${recipeId}, message: ${e?.message ?? String(e)}`);
         return jsonResult({
           error: e?.message ?? String(e),
           recipeId,

--- a/src/su-core/su-core-business-queries.js
+++ b/src/su-core/su-core-business-queries.js
@@ -823,6 +823,7 @@ export const initializeExecutiveBusinessQueryTools = async ({
     async (args) => {
       const credsForRequest = await Promise.resolve(c());
       const { recipeId, ...input } = args;
+      console.error(`[ExecutiveQuery] recipeId: ${recipeId}`);
       try {
         let payload;
         switch (recipeId) {

--- a/src/su-core/su-core-search-clients.js
+++ b/src/su-core/su-core-search-clients.js
@@ -1,5 +1,6 @@
 import { formatForClaude } from "./../utils.js";
 import { getSearchClientsToolAnnotations } from "../tool-annotations-meta.js";
+import { log } from "../logger.js";
 
 const initializeSearchClientsTools = async ({ server, creds, getCreds }) => {
   const credsForRequest = async () => (getCreds ? await getCreds() : creds);
@@ -12,15 +13,15 @@ const initializeSearchClientsTools = async ({ server, creds, getCreds }) => {
     async () => {
       const c = await credsForRequest();
       if (!c) {
-        console.error(`[SearchClients] unauthenticated`);
+        log(`[SearchClients] unauthenticated`);
         return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
       }
-      console.error(`[SearchClients] fetching search clients`);
+      log(`[SearchClients] fetching search clients`);
       const SearchClients = c.suRestClient.SearchClients();
       const response = await SearchClients.getSearchClients();
 
       if (!response?.data) {
-        console.error(`[SearchClients] API error — empty response`);
+        log(`[SearchClients] API error — empty response`);
         return { type: "text", text: "Error: no data in search clients response." };
       }
 

--- a/src/su-core/su-core-search-clients.js
+++ b/src/su-core/su-core-search-clients.js
@@ -12,6 +12,7 @@ const initializeSearchClientsTools = async ({ server, creds, getCreds }) => {
     async () => {
       const c = await credsForRequest();
       if (!c) return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
+      console.error(`[SearchClients] fetching search clients`);
       const SearchClients = c.suRestClient.SearchClients();
       const response = await SearchClients.getSearchClients();
 

--- a/src/su-core/su-core-search-clients.js
+++ b/src/su-core/su-core-search-clients.js
@@ -11,12 +11,16 @@ const initializeSearchClientsTools = async ({ server, creds, getCreds }) => {
     getSearchClientsToolAnnotations,
     async () => {
       const c = await credsForRequest();
-      if (!c) return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
+      if (!c) {
+        console.error(`[SearchClients] unauthenticated`);
+        return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
+      }
       console.error(`[SearchClients] fetching search clients`);
       const SearchClients = c.suRestClient.SearchClients();
       const response = await SearchClients.getSearchClients();
 
       if (!response?.data) {
+        console.error(`[SearchClients] API error — empty response`);
         return { type: "text", text: "Error: no data in search clients response." };
       }
 

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -101,6 +101,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       if (!effectiveUid) {
         return { content: [{ type: "text", text: "Search requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
       }
+      console.error(`[FilterOptions] query: "${searchString}" uid: ${effectiveUid}`);
       const Search = c.suRestClient.Search();
       const requestParams = { uid: effectiveUid, searchString, ...(c.config.email ? { email: c.config.email } : {}) };
       if (aggregations?.length) {

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -53,6 +53,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
     const searchResponse = await Search.getSearchResults(requestParams);
 
     if(!searchResponse?.data){
+      console.error(`[Search] API error — query: "${searchString}", response: ${JSON.stringify(searchResponse)}`);
       return {
         type: 'text',
         json: 'some error occured while searching, response is empty'

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -48,7 +48,8 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       requestParams.aggregations = aggregations.map((a) => ({ type: a.type, filter: [a.filter] }));
     }
 
-    console.error(`[Search] query: "${searchString}" uid: ${effectiveUid} email: ${c.config.email ?? '(none)'}`);
+    const maskedEmail = c.config.email ? `${c.config.email[0]}****@${c.config.email.split('@')[1]}` : '(none)';
+    console.error(`[Search] query: "${searchString}" uid: ${effectiveUid} email: ${maskedEmail}`);
     const searchResponse = await Search.getSearchResults(requestParams);
 
     if(!searchResponse?.data){

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { formatForClaude, formatArraysToString } from "./../utils.js";
+import { log } from "../logger.js";
 import {
   searchToolAnnotations,
   getFilterOptionsToolAnnotations,
@@ -24,7 +25,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
   }, searchToolAnnotations, async ({ searchString, aggregations, page, pageSize, sortBy, versionResults, uid }) => {
     const c = await credsForRequest();
     if (!c) {
-      console.error(`[Search] unauthenticated — query: "${searchString}"`);
+      log(`[Search] unauthenticated — query: "${searchString}"`);
       return { content: [{ type: "text", text: "Not authenticated. Please call the login tool first." }] };
     }
     const effectiveUid = uid?.trim() || c.config.uid;
@@ -52,11 +53,11 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
     }
 
     const maskedEmail = c.config.email ? `${c.config.email[0]}****@${c.config.email.split('@')[1]}` : '(none)';
-    console.error(`[Search] query: "${searchString}" uid: ${effectiveUid} email: ${maskedEmail}`);
+    log(`[Search] query: "${searchString}" uid: ${effectiveUid} email: ${maskedEmail}`);
     const searchResponse = await Search.getSearchResults(requestParams);
 
     if(!searchResponse?.data){
-      console.error(`[Search] API error — query: "${searchString}", response: ${JSON.stringify(searchResponse)}`);
+      log(`[Search] API error — query: "${searchString}", response: ${JSON.stringify(searchResponse)}`);
       return {
         type: 'text',
         json: 'some error occured while searching, response is empty'
@@ -100,14 +101,14 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
     async ({ searchString, aggregations, uid }) => {
       const c = await credsForRequest();
       if (!c) {
-        console.error(`[FilterOptions] unauthenticated — query: "${searchString}"`);
+        log(`[FilterOptions] unauthenticated — query: "${searchString}"`);
         return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
       }
       const effectiveUid = uid?.trim() || c.config.uid;
       if (!effectiveUid) {
         return { content: [{ type: "text", text: "Search requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
       }
-      console.error(`[FilterOptions] query: "${searchString}" uid: ${effectiveUid}`);
+      log(`[FilterOptions] query: "${searchString}" uid: ${effectiveUid}`);
       const Search = c.suRestClient.Search();
       const requestParams = { uid: effectiveUid, searchString, ...(c.config.email ? { email: c.config.email } : {}) };
       if (aggregations?.length) {
@@ -116,7 +117,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       const searchResponse = await Search.getSearchResults(requestParams);
 
       if (!searchResponse?.data) {
-        console.error(`[FilterOptions] API error — empty response for query: "${searchString}"`);
+        log(`[FilterOptions] API error — empty response for query: "${searchString}"`);
         return { type: "text", text: "Error: no data in search response." };
       }
 

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -19,20 +19,22 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
     pageSize: z.number().int().min(1).max(100).optional().describe("number of results per page, default is 10"),
     sortBy: z.enum(["_score", "post_time"]).optional().describe("field to sort results by, e.g. _score or post_time"),
     versionResults: z.boolean().default(false).optional().describe("Whether to use versioning for results. Defaults to false."),
+    uid: z.string().uuid().optional().describe("Optional search client UUID override. Required for ecosystem-only configs."),
     // sortOrder: z.enum(["asc", "desc"]).optional().describe("sort order for results, asc or desc"),
-  }, searchToolAnnotations, async ({ searchString, aggregations, page, pageSize, sortBy, versionResults }) => {
+  }, searchToolAnnotations, async ({ searchString, aggregations, page, pageSize, sortBy, versionResults, uid }) => {
     const c = await credsForRequest();
     if (!c) return { content: [{ type: "text", text: "Not authenticated. Please call the login tool first." }] };
+    const effectiveUid = uid?.trim() || c.config.uid;
+    if (!effectiveUid) {
+      return { content: [{ type: "text", text: "Search requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
+    }
     const Search = c.suRestClient.Search();
-    //const requestParams = { uid: c.config.uid, searchString };
-    
     const effectivePage = page ?? 1;
     const effectivePageSize = pageSize ?? 10;
     const from = (effectivePage - 1) * effectivePageSize;
 
-
     const requestParams = {
-      uid: c.config.uid,
+      uid: effectiveUid,
       searchString,
       from,
       resultsPerPage: effectivePageSize,
@@ -86,13 +88,18 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
     {
       searchString: z.string().min(3).max(100).describe("search query, a single word or sentence"),
       aggregations: z.array(aggregationSchema).optional().describe("optional list of current filters to get filter options in context of filtered results"),
+      uid: z.string().uuid().optional().describe("Optional search client UUID override. Required for ecosystem-only configs."),
     },
     getFilterOptionsToolAnnotations,
-    async ({ searchString, aggregations }) => {
+    async ({ searchString, aggregations, uid }) => {
       const c = await credsForRequest();
       if (!c) return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
+      const effectiveUid = uid?.trim() || c.config.uid;
+      if (!effectiveUid) {
+        return { content: [{ type: "text", text: "Search requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
+      }
       const Search = c.suRestClient.Search();
-      const requestParams = { uid: c.config.uid, searchString, ...(c.config.email ? { email: c.config.email } : {}) };
+      const requestParams = { uid: effectiveUid, searchString, ...(c.config.email ? { email: c.config.email } : {}) };
       if (aggregations?.length) {
         requestParams.aggregations = aggregations.map((a) => ({ type: a.type, filter: [a.filter] }));
       }

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -48,6 +48,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       requestParams.aggregations = aggregations.map((a) => ({ type: a.type, filter: [a.filter] }));
     }
 
+    console.error(`[Search] query: "${searchString}" uid: ${effectiveUid} email: ${c.config.email ?? '(none)'}`);
     const searchResponse = await Search.getSearchResults(requestParams);
 
     if(!searchResponse?.data){

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -23,7 +23,10 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
     // sortOrder: z.enum(["asc", "desc"]).optional().describe("sort order for results, asc or desc"),
   }, searchToolAnnotations, async ({ searchString, aggregations, page, pageSize, sortBy, versionResults, uid }) => {
     const c = await credsForRequest();
-    if (!c) return { content: [{ type: "text", text: "Not authenticated. Please call the login tool first." }] };
+    if (!c) {
+      console.error(`[Search] unauthenticated — query: "${searchString}"`);
+      return { content: [{ type: "text", text: "Not authenticated. Please call the login tool first." }] };
+    }
     const effectiveUid = uid?.trim() || c.config.uid;
     if (!effectiveUid) {
       return { content: [{ type: "text", text: "Search requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
@@ -96,7 +99,10 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
     getFilterOptionsToolAnnotations,
     async ({ searchString, aggregations, uid }) => {
       const c = await credsForRequest();
-      if (!c) return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
+      if (!c) {
+        console.error(`[FilterOptions] unauthenticated — query: "${searchString}"`);
+        return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
+      }
       const effectiveUid = uid?.trim() || c.config.uid;
       if (!effectiveUid) {
         return { content: [{ type: "text", text: "Search requires a search client UUID. Your MCP auth is configured with an ecosystem UUID. Pass the 'uid' parameter with a search client UUID (use 'get-search-clients' to find available ones)." }] };
@@ -110,6 +116,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       const searchResponse = await Search.getSearchResults(requestParams);
 
       if (!searchResponse?.data) {
+        console.error(`[FilterOptions] API error — empty response for query: "${searchString}"`);
         return { type: "text", text: "Error: no data in search response." };
       }
 

--- a/src/su-core/su-core-search.js
+++ b/src/su-core/su-core-search.js
@@ -38,7 +38,8 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       resultsPerPage: effectivePageSize,
       versionResults: !!versionResults,
       ...(sortBy ? { sortby: sortBy } : {}),
-      orderBy: 'desc'
+      orderBy: 'desc',
+      ...(c.config.email ? { email: c.config.email } : {}),
    };
     
     if (aggregations?.length) {
@@ -91,7 +92,7 @@ const initializeSearchTools = async ({ server, creds, getCreds }) => {
       const c = await credsForRequest();
       if (!c) return { content: [{ type: "text", text: "IMPORTANT: Not authenticated. You MUST call the 'login' tool first to get a login link for the user. Do not ask the user to go to settings — use the login tool." }] };
       const Search = c.suRestClient.Search();
-      const requestParams = { uid: c.config.uid, searchString };
+      const requestParams = { uid: c.config.uid, searchString, ...(c.config.email ? { email: c.config.email } : {}) };
       if (aggregations?.length) {
         requestParams.aggregations = aggregations.map((a) => ({ type: a.type, filter: [a.filter] }));
       }

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,5 +1,6 @@
 import { initializeSuCoreTools } from "./su-core/index.js";
 import { loginToolAnnotations } from "./tool-annotations-meta.js";
+import { log } from "./logger.js";
 
 export const initializeTools = async ({ server, creds, getCreds, mcpSessionId, oauthProvider }) => {
   await initializeSuCoreTools({ server, creds, getCreds });
@@ -14,7 +15,7 @@ export const initializeTools = async ({ server, creds, getCreds, mcpSessionId, o
       {},
       loginToolAnnotations,
       async () => {
-        console.error(`[Login] login tool called — session: ${mcpSessionId.slice(0, 8)}...`);
+        log(`[Login] login tool called — session: ${mcpSessionId.slice(0, 8)}...`);
         const loginUrl = `${base}/mcp-connect/login?s=${encodeURIComponent(mcpSessionId)}`;
         return {
           content: [{

--- a/src/tools.js
+++ b/src/tools.js
@@ -14,6 +14,7 @@ export const initializeTools = async ({ server, creds, getCreds, mcpSessionId, o
       {},
       loginToolAnnotations,
       async () => {
+        console.error(`[Login] login tool called — session: ${mcpSessionId.slice(0, 8)}...`);
         const loginUrl = `${base}/mcp-connect/login?s=${encodeURIComponent(mcpSessionId)}`;
         return {
           content: [{

--- a/src/validations.js
+++ b/src/validations.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { log } from './logger.js';
 import { dirname } from 'path';
 import { SearchUnifyRestClient, AUTH_TYPES } from "su-sdk";
 
@@ -34,7 +35,7 @@ function validateAndLoadJSON(filePath) {
 }
 
 const validateCreds = () => {
-  console.error ('Validating creds...');
+  log('Validating creds...');
   const credsPath = path.join(__dirname, 'input', 'creds.json');
   const config = validateAndLoadJSON(credsPath);
   if(!config.uid && !config.ecoSystemId){
@@ -48,7 +49,7 @@ const validateCreds = () => {
   delete restClientConfig.ecoSystemId;
   // instance: platform base URL (e.g. https://host); su-sdk appends /api/v2/... from ANALYTICS.* — duplicate /api/v2 on instance is normalized away in SearchUnifyRestClient
   const suRestClient = new SearchUnifyRestClient(restClientConfig);
-  console.error ('created sdk connection...');
+  log('created sdk connection...');
   return {
     suRestClient,
     config

--- a/src/validations.js
+++ b/src/validations.js
@@ -113,7 +113,7 @@ function getCredsFromHeaders(headers) {
  * @param {Object} suTokens - { accessToken, refreshToken, instanceUrl }
  */
 function buildCredsFromSuToken(suTokens) {
-  const { instanceUrl, suClientId, suClientSecret, uid } = suTokens;
+  const { instanceUrl, suClientId, suClientSecret, uid, email } = suTokens;
   const suRestClient = new SearchUnifyRestClient({
     instance: instanceUrl,
     timeout: parseInt(process.env.SU_TIMEOUT || "60000", 10),
@@ -123,7 +123,7 @@ function buildCredsFromSuToken(suTokens) {
       clientSecret: suClientSecret,
     },
   });
-  return { suRestClient, config: { instance: instanceUrl, uid } };
+  return { suRestClient, config: { instance: instanceUrl, uid, email: email ?? null } };
 }
 
 export { validateCreds, getCredsFromHeaders, buildCredsFromSuToken };

--- a/src/validations.js
+++ b/src/validations.js
@@ -41,7 +41,6 @@ const validateCreds = () => {
     throw new Error('Invalid parameter: uid or ecoSystemId is required in the config file.');
   }
   if (config.ecoSystemId) {
-    config.ecoSystemId = config.ecoSystemId;
     config.uid = config.uid ?? null;
   }
   const restClientConfig = { ...config, sendMcpConsumptionTrack: true };
@@ -109,6 +108,7 @@ function getCredsFromHeaders(headers) {
     sendMcpConsumptionTrack: true,
   };
   delete restClientConfig.uid;
+  delete restClientConfig.ecoSystemId;
   // instance: platform base URL; su-sdk appends /api/v2/... (SearchUnifyRestClient strips duplicate trailing /api/v2)
   const suRestClient = new SearchUnifyRestClient(restClientConfig);
   return { suRestClient, config: { ...config, uid } };

--- a/src/validations.js
+++ b/src/validations.js
@@ -37,11 +37,16 @@ const validateCreds = () => {
   console.error ('Validating creds...');
   const credsPath = path.join(__dirname, 'input', 'creds.json');
   const config = validateAndLoadJSON(credsPath);
-  if(!config.uid){
-    throw new Error('Invalid parameter: uid is required in the config file.');
+  if(!config.uid && !config.ecoSystemId){
+    throw new Error('Invalid parameter: uid or ecoSystemId is required in the config file.');
+  }
+  if (config.ecoSystemId) {
+    config.ecoSystemId = config.ecoSystemId;
+    config.uid = config.uid ?? null;
   }
   const restClientConfig = { ...config, sendMcpConsumptionTrack: true };
   delete restClientConfig.uid;
+  delete restClientConfig.ecoSystemId;
   // instance: platform base URL (e.g. https://host); su-sdk appends /api/v2/... from ANALYTICS.* — duplicate /api/v2 on instance is normalized away in SearchUnifyRestClient
   const suRestClient = new SearchUnifyRestClient(restClientConfig);
   console.error ('created sdk connection...');
@@ -66,12 +71,16 @@ function getCredsFromHeaders(headers) {
   const authType = (get('auth-type') || 'apiKey').toLowerCase();
   const timeout = parseInt(get('timeout') || '60000', 10);
 
+  const ecosystemId = get('ecosystem-id')?.trim();
   const config = {
     instance,
     uid,
     timeout: Number.isFinite(timeout) ? timeout : 60000,
     authType: authType === 'apikey' ? 'apiKey' : authType === 'clientcredentials' ? 'clientCredentials' : authType,
   };
+  if (ecosystemId) {
+    config.ecoSystemId = ecosystemId;
+  }
 
   if (config.authType === 'apiKey') {
     const apiKey = get('api-key');
@@ -113,7 +122,7 @@ function getCredsFromHeaders(headers) {
  * @param {Object} suTokens - { accessToken, refreshToken, instanceUrl }
  */
 function buildCredsFromSuToken(suTokens) {
-  const { instanceUrl, suClientId, suClientSecret, uid, email } = suTokens;
+  const { instanceUrl, suClientId, suClientSecret, uid, email, isEcosystem } = suTokens;
   const suRestClient = new SearchUnifyRestClient({
     instance: instanceUrl,
     timeout: parseInt(process.env.SU_TIMEOUT || "60000", 10),
@@ -123,7 +132,15 @@ function buildCredsFromSuToken(suTokens) {
       clientSecret: suClientSecret,
     },
   });
-  return { suRestClient, config: { instance: instanceUrl, uid, email: email ?? null } };
+  const config = { instance: instanceUrl, email: email ?? null };
+  if (isEcosystem === true) {
+    config.ecoSystemId = uid;
+    config.uid = null;
+  } else {
+    config.uid = uid;
+    config.ecoSystemId = null;
+  }
+  return { suRestClient, config };
 }
 
 export { validateCreds, getCredsFromHeaders, buildCredsFromSuToken };

--- a/test/mcp-api-headers.test.js
+++ b/test/mcp-api-headers.test.js
@@ -1,0 +1,77 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+process.env.OAUTH_ENCRYPTION_KEY = "a".repeat(64);
+
+const { getCredsFromHeaders } = await import("../src/validations.js");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function apiKeyHeaders(overrides = {}) {
+  return {
+    "searchunify-instance": "https://acme.searchunify.com",
+    "searchunify-uid": "uid123",
+    "searchunify-auth-type": "apiKey",
+    "searchunify-api-key": "testapikey",
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("getCredsFromHeaders — /mcp-api auth", () => {
+  it("returns null when searchunify-instance is missing", () => {
+    const headers = apiKeyHeaders({ "searchunify-instance": undefined });
+    assert.equal(getCredsFromHeaders(headers), null);
+  });
+
+  it("returns null when searchunify-uid is missing", () => {
+    const headers = apiKeyHeaders({ "searchunify-uid": undefined });
+    assert.equal(getCredsFromHeaders(headers), null);
+  });
+
+  it("returns null when searchunify-api-key is missing for apiKey auth", () => {
+    const headers = apiKeyHeaders({ "searchunify-api-key": undefined });
+    assert.equal(getCredsFromHeaders(headers), null);
+  });
+
+  it("returns null for an unknown auth type", () => {
+    const headers = apiKeyHeaders({ "searchunify-auth-type": "magic" });
+    assert.equal(getCredsFromHeaders(headers), null);
+  });
+
+  it("returns valid creds for correct apiKey headers", () => {
+    const creds = getCredsFromHeaders(apiKeyHeaders());
+    assert.ok(creds, "expected non-null creds");
+    assert.equal(creds.config.instance, "https://acme.searchunify.com");
+    assert.equal(creds.config.uid, "uid123");
+    assert.equal(creds.config.authType, "apiKey");
+    assert.equal(creds.config.apiKey, "testapikey");
+    assert.ok(creds.suRestClient, "expected suRestClient to be present");
+  });
+
+  it("defaults auth type to apiKey when searchunify-auth-type header is absent", () => {
+    const headers = apiKeyHeaders({ "searchunify-auth-type": undefined });
+    const creds = getCredsFromHeaders(headers);
+    assert.ok(creds, "expected non-null creds when auth-type defaults to apiKey");
+    assert.equal(creds.config.authType, "apiKey");
+  });
+
+  it("trims instance and uid values", () => {
+    const headers = apiKeyHeaders({
+      "searchunify-instance": "  https://acme.searchunify.com  ",
+      "searchunify-uid": "  uid123  ",
+    });
+    const creds = getCredsFromHeaders(headers);
+    assert.ok(creds);
+    assert.equal(creds.config.instance, "https://acme.searchunify.com");
+    assert.equal(creds.config.uid, "uid123");
+  });
+
+  it("includes ecosystemId in config when searchunify-ecosystem-id header is set", () => {
+    const headers = apiKeyHeaders({ "searchunify-ecosystem-id": "eco-abc" });
+    const creds = getCredsFromHeaders(headers);
+    assert.ok(creds);
+    assert.equal(creds.config.ecoSystemId, "eco-abc");
+  });
+});


### PR DESCRIPTION
 Ecosystem UUID support for MCP

  When a user configures su-mcp with an ecosystem UUID, all API calls were returning 401. This PR fixes that by:

  - OAuth: auto-detects uid type at login by calling GET /api/v2/search-clients. If ecosystem → stores as ecoSystemId in session. If uid not found → fails auth with a clear error page.
  - Header auth: new searchunify-ecosystem-id header.
  - Stdio auth: new ecoSystemId field in creds.json.
  - Analytics/Search: ecosystem-aware scope building across all relevant tools; null-uid guard on endpoints that don't support ecosystem scope.

  Depends on admin MR !6035 (adds ecosystem rows + type field to /api/v2/search-clients).